### PR TITLE
Feature/i39 async flag for import scan

### DIFF
--- a/client/scans.go
+++ b/client/scans.go
@@ -138,7 +138,6 @@ func (c *Client) FindScanByID(id string) (*Scan, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-
 		return nil, fmt.Errorf("HTTP response not OK: %d", resp.StatusCode)
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -28,6 +28,7 @@ func init() {
 	importCmd.Flags().StringP("tool", "t", "", "tool name")
 	importCmd.Flags().StringP("branch", "b", "", "branch")
 	importCmd.Flags().Bool("async", false, "does not block build process")
+	importCmd.Flags().Int("timeout", 0, "minutes to wait for import to finish. import will continue async if duration exceeds limit")
 
 	_ = importCmd.MarkFlagRequired("project")
 	_ = importCmd.MarkFlagRequired("tool")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,12 +6,10 @@ Copyright © 2019 Kondukto
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
-	"text/tabwriter"
 
 	"github.com/kondukto-io/kdt/client"
+	"github.com/kondukto-io/kdt/klog"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +27,7 @@ func init() {
 	importCmd.Flags().StringP("project", "p", "", "project name or id")
 	importCmd.Flags().StringP("tool", "t", "", "tool name")
 	importCmd.Flags().StringP("branch", "b", "", "branch")
+	importCmd.Flags().Bool("async", false, "does not block build process")
 
 	_ = importCmd.MarkFlagRequired("project")
 	_ = importCmd.MarkFlagRequired("tool")
@@ -75,10 +74,23 @@ func importRootCommand(cmd *cobra.Command, args []string) {
 		qwe(1, err, "failed to import scan results")
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-	_, _ = fmt.Fprintf(w, "Event ID\n")
-	_, _ = fmt.Fprintf(w, "---\n")
-	_, _ = fmt.Fprintf(w, "%s\n", eventID)
-	_ = w.Flush()
+	async, err := cmd.Flags().GetBool("async")
+	if err != nil {
+		klog.Fatalf("failed to parse async flag: %v", err)
+	}
+
+	// Do not wait for import to finish if async set to true
+	if async {
+		eventRows := []Row{
+			{Columns: []string{"EVENT ID"}},
+			{Columns: []string{"--------"}},
+			{Columns: []string{eventID}},
+		}
+		tableWriter(eventRows...)
+		qwm(0, "import has been started with async parameter, exiting.")
+	}
+
+	waitTillScanEnded(cmd, c, eventID)
+
 	qwm(0, "scan results imported successfully")
 }

--- a/cmd/listProjects.go
+++ b/cmd/listProjects.go
@@ -6,10 +6,6 @@ Copyright © 2019 Kondukto
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"text/tabwriter"
-
 	"github.com/kondukto-io/kdt/client"
 	"github.com/spf13/cobra"
 )
@@ -45,12 +41,12 @@ func projectsRootCommand(_ *cobra.Command, args []string) {
 		qwm(1, "no projects found")
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-	defer func() { _ = w.Flush() }()
-
-	_, _ = fmt.Fprintln(w, "NAME\tID")
-	_, _ = fmt.Fprintln(w, "---\t---")
-	for _, project := range projects {
-		_, _ = fmt.Fprintf(w, "%s\t%s\n", project.Name, project.ID)
+	projectRows := []Row{
+		{Columns: []string{"NAME", "ID"}},
+		{Columns: []string{"----", "----"}},
 	}
+	for _, project := range projects {
+		projectRows = append(projectRows, Row{Columns: []string{project.Name, project.ID}})
+	}
+	tableWriter(projectRows...)
 }

--- a/cmd/listProjects.go
+++ b/cmd/listProjects.go
@@ -43,7 +43,7 @@ func projectsRootCommand(_ *cobra.Command, args []string) {
 
 	projectRows := []Row{
 		{Columns: []string{"NAME", "ID"}},
-		{Columns: []string{"----", "----"}},
+		{Columns: []string{"----", "--"}},
 	}
 	for _, project := range projects {
 		projectRows = append(projectRows, Row{Columns: []string{project.Name, project.ID}})

--- a/cmd/listScanners.go
+++ b/cmd/listScanners.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"text/tabwriter"
-
 	"github.com/spf13/cobra"
 )
 
@@ -12,14 +8,14 @@ var listScannersCmd = &cobra.Command{
 	Use:   "scanners",
 	Short: "list supported scanners",
 	Run: func(cmd *cobra.Command, args []string) {
-		w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-		defer func() { _ = w.Flush() }()
-
-		_, _ = fmt.Fprintf(w, "Tool Name\tScanner Type\n")
-		_, _ = fmt.Fprintf(w, "------\t------\n")
-		for k, v := range scanners {
-			_, _ = fmt.Fprintf(w, "%s\t%s\n", k, v)
+		scannerRows := []Row{
+			{Columns: []string{"Tool Name", "Scanner Type"}},
+			{Columns: []string{"------", "------"}},
 		}
+		for k, v := range scanners {
+			scannerRows = append(scannerRows, Row{Columns: []string{k, v}})
+		}
+		tableWriter(scannerRows...)
 	},
 }
 

--- a/cmd/listScans.go
+++ b/cmd/listScans.go
@@ -6,10 +6,6 @@ Copyright © 2019 Kondukto
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"text/tabwriter"
-
 	"github.com/kondukto-io/kdt/client"
 	"github.com/spf13/cobra"
 )
@@ -44,13 +40,16 @@ func scanListRootCommand(cmd *cobra.Command, _ []string) {
 		qwm(1, "no scans found with the project id/name")
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-	defer func() { _ = w.Flush() }()
-
-	_, _ = fmt.Fprintf(w, "NAME\tID\tBRANCH\tMETA\tTOOL\tCRIT\tHIGH\tMED\tLOW\tSCORE\tDATE\n")
-	_, _ = fmt.Fprintf(w, "---\t---\t---\t---\t---\t---\t---\t---\t---\t---\n")
-	for _, scan := range scans {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n", scan.Name, scan.ID, scan.Branch, scan.MetaData,
-			scan.Tool, scan.Summary.Critical, scan.Summary.High, scan.Summary.Medium, scan.Summary.Low, scan.Score, scan.Date)
+	scanSummaryRows := []Row{
+		{Columns: []string{"NAME", "ID", "BRANCH", "META", "TOOL", "CRIT", "HIGH", "MED", "LOW", "SCORE", "DATE"}},
+		{Columns: []string{"----", "--", "------", "----", "----", "----", "----", "---", "---", "-----", "----"}},
 	}
+
+	for _, scan := range scans {
+		s := scan.Summary
+		name, id, branch, meta, tool, date := scan.Name, scan.ID, scan.Branch, scan.MetaData, scan.Tool, scan.Date.String()
+		crit, high, med, low, score := strC(s.Critical), strC(s.High), strC(s.Medium), strC(s.Low), strC(scan.Score)
+		scanSummaryRows = append(scanSummaryRows, Row{Columns: []string{name, id, branch, meta, tool, crit, high, med, low, score, date}})
+	}
+	tableWriter(scanSummaryRows...)
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -7,8 +7,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	"github.com/kondukto-io/kdt/klog"
 
@@ -57,11 +55,12 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		qwm(0, "project has no release criteria")
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-	_, _ = fmt.Fprintf(w, "STATUS\tSAST\tDAST\tSCA\n")
-	_, _ = fmt.Fprintf(w, "---\t---\t---\t---\n")
-	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n\n", rs.Status, rs.SAST.Status, rs.DAST.Status, rs.SCA.Status)
-	_ = w.Flush()
+	releaseCriteriaRows := []Row{
+		{Columns: []string{"STATUS", "SAST", "DAST", "SCA"}},
+		{Columns: []string{"------", "----", "----", "---"}},
+		{Columns: []string{rs.Status, rs.SAST.Status, rs.DAST.Status, rs.SCA.Status}},
+	}
+	tableWriter(releaseCriteriaRows...)
 
 	sast, err := cmd.Flags().GetBool("sast")
 	if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -55,7 +55,7 @@ func statusRootCommand(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	summary, err := c.GetScanSummary(scan.ID)
+	summary, err := c.FindScanByID(scan.ID)
 	if err != nil {
 		qwe(1, err, "failed to fetch scan summary")
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -8,6 +8,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"text/tabwriter"
 
 	"github.com/kondukto-io/kdt/klog"
 )
@@ -58,3 +60,21 @@ func validTool(t string) bool {
 	}
 	return false
 }
+
+type Row struct {
+	Columns []string
+}
+
+func tableWriter(rows ...Row) {
+	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
+	for _, row := range rows {
+		var r string
+		for _, column := range row.Columns {
+			r += fmt.Sprintf("%s\t", column)
+		}
+		_, _ = fmt.Fprintf(w, "%s\n", r)
+	}
+	_ = w.Flush()
+}
+
+func strC(v int) string { return strconv.Itoa(v) }


### PR DESCRIPTION
* Replaces new Table Print
* Adds a new async flag for scan by file command
* Adds release criteria status for imported scan files

Fixes
* Missing project name bug for restart a scan command
* Missing project name bug for check project security criteri command