### PR TITLE
Release/i42 start a new scan

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -102,6 +102,9 @@ func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 			klog.Debugf("failed to parse error message: %v: %v", err, data)
 			return nil, err
 		}
+		if e.Error == "" {
+			return nil, fmt.Errorf("respons not OK: %s", string(data))
+		}
 		return nil, fmt.Errorf("response not OK: %s", e.Error)
 	}
 

--- a/client/projects.go
+++ b/client/projects.go
@@ -14,8 +14,11 @@ import (
 )
 
 type Project struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Links struct {
+		HTML string `json:"html"`
+	} `json:"links"`
 }
 
 func (c *Client) ListProjects(arg string) ([]Project, error) {

--- a/client/scanners.go
+++ b/client/scanners.go
@@ -21,16 +21,26 @@ type (
 		Limit  int    `url:"limit"`
 	}
 	ScannersResponse struct {
-		ActiveScanners []struct {
-			Id          string   `json:"id"`
-			Type        string   `json:"type"`
-			Slug        string   `json:"slug"`
-			DisplayName string   `json:"display_name"`
-			Labels      []string `json:"labels"`
-			CustomType  int      `json:"custom_type"`
-		} `json:"active_scanners"`
-		Total int `json:"total"`
+		ActiveScanners []ScannerInfo `json:"active_scanners"`
+		Total          int           `json:"total"`
 	}
+	ScannerInfo struct {
+		Id          string   `json:"id"`
+		Type        string   `json:"type"`
+		Slug        string   `json:"slug"`
+		DisplayName string   `json:"display_name"`
+		Labels      []string `json:"labels"`
+		CustomType  int      `json:"custom_type"`
+	}
+)
+
+const (
+	ScannerLabelKDT      = "kdt"
+	ScannerLabelBind     = "bind"
+	ScannerLabelAgent    = "agent"
+	ScannerLabelDocker   = "docker"
+	ScannerLabelImport   = "import"
+	ScannerLabelTemplate = "template"
 )
 
 func (c *Client) ListActiveScanners(params *ScannersSearchParams) (*ScannersResponse, error) {
@@ -59,4 +69,21 @@ func (c *Client) ListActiveScanners(params *ScannersSearchParams) (*ScannersResp
 	}
 
 	return &scanners, nil
+}
+
+func (c *Client) IsValidTool(tool string) bool {
+	klog.Debugf("validating tool name")
+
+	scanners, err := c.ListActiveScanners(&ScannersSearchParams{Name: tool})
+	if err != nil {
+		klog.Debugf("failed to get active scanners: %v", err)
+		return false
+	}
+
+	if scanners.Total == 0 {
+		klog.Debugf("invalid or inactive tool name: %s", tool)
+		return false
+	}
+
+	return true
 }

--- a/client/scanners.go
+++ b/client/scanners.go
@@ -15,10 +15,10 @@ import (
 
 type (
 	ScannersSearchParams struct {
-		Type   string   `url:"branch,omitempty"`
-		Labels []string `url:"tool,omitempty"`
-		Name   string   `url:"meta,omitempty"`
-		Limit  int      `url:"limit,omitempty"`
+		Types  string `url:"types"`
+		Labels string `url:"labels"`
+		Name   string `url:"name"`
+		Limit  int    `url:"limit"`
 	}
 	ScannersResponse struct {
 		ActiveScanners []struct {
@@ -33,7 +33,7 @@ type (
 	}
 )
 
-func (c *Client) ListActiveScanners(params *ScanSearchParams) (*ScannersResponse, error) {
+func (c *Client) ListActiveScanners(params *ScannersSearchParams) (*ScannersResponse, error) {
 	klog.Debugf("retrieving active scanners")
 
 	path := fmt.Sprintf("/api/v1/scanners/active")

--- a/client/scanners.go
+++ b/client/scanners.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2021 Kondukto
-Created by Yusuf Eyisan aka @yeyisan
 */
 
 package client

--- a/client/scanners.go
+++ b/client/scanners.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2021 Kondukto
+Created by Yusuf Eyisan aka @yeyisan
+*/
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+	"github.com/kondukto-io/kdt/klog"
+)
+
+type (
+	ScannersSearchParams struct {
+		Type   string   `url:"branch,omitempty"`
+		Labels []string `url:"tool,omitempty"`
+		Name   string   `url:"meta,omitempty"`
+		Limit  int      `url:"limit,omitempty"`
+	}
+	ScannersResponse struct {
+		ActiveScanners []struct {
+			Id          string   `json:"id"`
+			Type        string   `json:"type"`
+			Slug        string   `json:"slug"`
+			DisplayName string   `json:"display_name"`
+			Labels      []string `json:"labels"`
+			CustomType  int      `json:"custom_type"`
+		} `json:"active_scanners"`
+		Total int `json:"total"`
+	}
+)
+
+func (c *Client) ListActiveScanners(params *ScanSearchParams) (*ScannersResponse, error) {
+	klog.Debugf("retrieving active scanners")
+
+	path := fmt.Sprintf("/api/v1/scanners/active")
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = v.Encode()
+
+	var scanners ScannersResponse
+	res, err := c.do(req, &scanners)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP response not OK: %d", res.StatusCode)
+	}
+
+	return &scanners, nil
+}

--- a/client/scanparams.go
+++ b/client/scanparams.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2021 Kondukto
-Created by Yusuf Eyisan aka @yeyisan
 */
 
 package client

--- a/client/scanparams.go
+++ b/client/scanparams.go
@@ -19,6 +19,7 @@ type (
 		ToolID string `url:"tool_id"`
 		Branch string `url:"branch"`
 		Limit  int    `url:"limit"`
+		Manual bool   `url:"manual"`
 	}
 	ScanparamResponse struct {
 		Data  []ScanparamsDetail `json:"data"`
@@ -37,7 +38,7 @@ func (c *Client) FindScanparams(project string, params *ScanparamSearchParams) (
 		return nil, errors.New("missing project identifier")
 	}
 
-	path := fmt.Sprintf("/api/v1/projects%s/scanparams", project)
+	path := fmt.Sprintf("/api/v1/projects/%s/scanparams", project)
 	req, err := c.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/client/scanparams.go
+++ b/client/scanparams.go
@@ -31,7 +31,7 @@ type (
 	}
 )
 
-func (c *Client) FindScanparams(project string, params *ScanparamSearchParams) (*ScanparamResponse, error) {
+func (c *Client) FindScanparams(project string, params *ScanparamSearchParams) (*ScanparamsDetail, error) {
 	klog.Debugf("retrieving scanparams")
 	if project == "" {
 		return nil, errors.New("missing project identifier")
@@ -55,5 +55,9 @@ func (c *Client) FindScanparams(project string, params *ScanparamSearchParams) (
 		return nil, err
 	}
 
-	return &scanparams, nil
+	if scanparams.Total == 0 {
+		return nil, errors.New("scanparams not found")
+	}
+
+	return &scanparams.Data[0], nil
 }

--- a/client/scanparams.go
+++ b/client/scanparams.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2021 Kondukto
+Created by Yusuf Eyisan aka @yeyisan
+*/
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+	"github.com/kondukto-io/kdt/klog"
+)
+
+type (
+	ScanparamSearchParams struct {
+		ToolID string `url:"tool_id"`
+		Branch string `url:"branch"`
+		Limit  int    `url:"limit"`
+	}
+	ScanparamResponse struct {
+		Data  []ScanparamsDetail `json:"data"`
+		Total int                `json:"total"`
+	}
+	ScanparamsDetail struct {
+		Id       string `json:"id"`
+		Branch   string `json:"branch"`
+		BindName string `json:"bind_name"`
+	}
+)
+
+func (c *Client) FindScanparams(project string, params *ScanparamSearchParams) (*ScanparamResponse, error) {
+	klog.Debugf("retrieving scanparams")
+	if project == "" {
+		return nil, errors.New("missing project identifier")
+	}
+
+	path := fmt.Sprintf("/api/v1/projects%s/scanparams", project)
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = v.Encode()
+
+	var scanparams ScanparamResponse
+	_, err = c.do(req, &scanparams)
+	if err != nil {
+		return nil, err
+	}
+
+	return &scanparams, nil
+}

--- a/client/scans.go
+++ b/client/scans.go
@@ -71,13 +71,13 @@ type (
 
 	Scan struct {
 		// ScanparamsID is holding identifier of scanparams, when given, it will override other fields
-		ScanparamsID string `json:"scanparams_id"`
+		ScanparamsID string `json:"scanparams_id,omitempty"`
 		// Branch is holding current branch value of scan
 		Branch string `json:"branch"`
 		// Project is holding ID or Name value of project
 		Project string `json:"project"`
 		// ToolID is holding ID value of selected scanner
-		ToolID string `json:"tool_id"`
+		ToolID string `json:"tool_id,omitempty"`
 		// PR is holding detail of pull requests branches to be scanned
 		PR PRInfo `json:"pr"`
 		// Custom is holding custom type of scanners that specified on the Kondukto side

--- a/client/scans.go
+++ b/client/scans.go
@@ -70,6 +70,8 @@ type (
 	}
 
 	Scan struct {
+		// ScanparamsID is holding identifier of scanparams, when given, it will override other fields
+		ScanparamsID string `json:"scanparams_id"`
 		// Branch is holding current branch value of scan
 		Branch string `json:"branch"`
 		// Project is holding ID or Name value of project

--- a/client/scans.go
+++ b/client/scans.go
@@ -70,6 +70,9 @@ type (
 		Active  int    `json:"active"`
 		ScanId  string `json:"scan_id"`
 		Message string `json:"message"`
+		Links   struct {
+			HTML string `json:"html"`
+		} `json:"links"`
 	}
 
 	Scan struct {

--- a/client/scans.go
+++ b/client/scans.go
@@ -34,6 +34,9 @@ type (
 		Project  string     `json:"project"`
 		Score    int        `json:"score"`
 		Summary  Summary    `json:"summary"`
+		Links    struct {
+			HTML string `json:"html"`
+		} `json:"links"`
 	}
 
 	ScanSearchParams struct {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -87,7 +87,7 @@ func importRootCommand(cmd *cobra.Command, args []string) {
 			{Columns: []string{"--------"}},
 			{Columns: []string{eventID}},
 		}
-		tableWriter(eventRows...)
+		TableWriter(eventRows...)
 		qwm(0, "import has been started with async parameter, exiting.")
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -60,8 +60,8 @@ func importRootCommand(cmd *cobra.Command, args []string) {
 		qwe(1, err, "failed to parse tool flag")
 	}
 
-	if !validTool(tool) {
-		qwm(1, "invalid tool name")
+	if !c.IsValidTool(tool) {
+		qwm(1, "invalid or inactive tool name")
 	}
 
 	path := args[0]

--- a/cmd/listProjects.go
+++ b/cmd/listProjects.go
@@ -42,11 +42,11 @@ func projectsRootCommand(_ *cobra.Command, args []string) {
 	}
 
 	projectRows := []Row{
-		{Columns: []string{"NAME", "ID"}},
-		{Columns: []string{"----", "--"}},
+		{Columns: []string{"NAME", "ID", "UI Link"}},
+		{Columns: []string{"----", "--", "-------"}},
 	}
 	for _, project := range projects {
-		projectRows = append(projectRows, Row{Columns: []string{project.Name, project.ID}})
+		projectRows = append(projectRows, Row{Columns: []string{project.Name, project.ID, project.Links.HTML}})
 	}
 	TableWriter(projectRows...)
 }

--- a/cmd/listProjects.go
+++ b/cmd/listProjects.go
@@ -48,5 +48,5 @@ func projectsRootCommand(_ *cobra.Command, args []string) {
 	for _, project := range projects {
 		projectRows = append(projectRows, Row{Columns: []string{project.Name, project.ID}})
 	}
-	tableWriter(projectRows...)
+	TableWriter(projectRows...)
 }

--- a/cmd/listScanners.go
+++ b/cmd/listScanners.go
@@ -26,12 +26,24 @@ var listScannersCmd = &cobra.Command{
 			qwe(1, err, "could not get Kondukto active scanners")
 		}
 
+		var rescanOnly = func(labels []string) string {
+			rescanOnlyLabels := []string{client.ScannerLabelAgent, client.ScannerLabelBind, client.ScannerLabelTemplate}
+			for _, r := range rescanOnlyLabels {
+				for _, l := range labels {
+					if l == r {
+						return "rescan"
+					}
+				}
+			}
+			return "new scan"
+		}
+
 		scannerRows := []Row{
-			{Columns: []string{"Name", "ID", "Type", "Labels"}},
-			{Columns: []string{"----", "--", "----", "------"}},
+			{Columns: []string{"Name", "ID", "Type", "Trigger", "Labels"}},
+			{Columns: []string{"----", "--", "----", "-------", "------"}},
 		}
 		for _, v := range activeScanners.ActiveScanners {
-			scannerRows = append(scannerRows, Row{Columns: []string{v.Slug, v.Id, v.Type, strings.Join(v.Labels, ",")}})
+			scannerRows = append(scannerRows, Row{Columns: []string{v.Slug, v.Id, v.Type, rescanOnly(v.Labels), strings.Join(v.Labels, ",")}})
 		}
 		if len(scannerRows) == 2 {
 			scannerRows = append(scannerRows, Row{Columns: []string{"no found active scanner"}})

--- a/cmd/listScanners.go
+++ b/cmd/listScanners.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"strings"
+
+	"github.com/kondukto-io/kdt/client"
 	"github.com/spf13/cobra"
 )
 
@@ -8,12 +11,22 @@ var listScannersCmd = &cobra.Command{
 	Use:   "scanners",
 	Short: "list supported scanners",
 	Run: func(cmd *cobra.Command, args []string) {
-		scannerRows := []Row{
-			{Columns: []string{"Tool Name", "Scanner Type"}},
-			{Columns: []string{"------", "------"}},
+		c, err := client.New()
+		if err != nil {
+			qwe(1, err, "could not initialize Kondukto client")
 		}
-		for k, v := range scanners {
-			scannerRows = append(scannerRows, Row{Columns: []string{k, v}})
+
+		activeScanners, err := c.ListActiveScanners(nil)
+		if err != nil {
+			qwe(1, err, "could not get Kondukto active scanners")
+		}
+
+		scannerRows := []Row{
+			{Columns: []string{"ID", "Name", "Type", "Labels"}},
+			{Columns: []string{"--", "----", "----", "------"}},
+		}
+		for _, v := range activeScanners.ActiveScanners {
+			scannerRows = append(scannerRows, Row{Columns: []string{v.Id, v.Slug, v.Type, strings.Join(v.Labels, ",")}})
 		}
 		tableWriter(scannerRows...)
 	},

--- a/cmd/listScanners.go
+++ b/cmd/listScanners.go
@@ -36,7 +36,7 @@ var listScannersCmd = &cobra.Command{
 		if len(scannerRows) == 2 {
 			scannerRows = append(scannerRows, Row{Columns: []string{"no found active scanner"}})
 		}
-		tableWriter(scannerRows...)
+		TableWriter(scannerRows...)
 	},
 }
 

--- a/cmd/listScans.go
+++ b/cmd/listScans.go
@@ -51,5 +51,5 @@ func scanListRootCommand(cmd *cobra.Command, _ []string) {
 		crit, high, med, low, score := strC(s.Critical), strC(s.High), strC(s.Medium), strC(s.Low), strC(scan.Score)
 		scanSummaryRows = append(scanSummaryRows, Row{Columns: []string{name, id, branch, meta, tool, crit, high, med, low, score, date}})
 	}
-	tableWriter(scanSummaryRows...)
+	TableWriter(scanSummaryRows...)
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -60,7 +60,7 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		{Columns: []string{"------", "----", "----", "---"}},
 		{Columns: []string{rs.Status, rs.SAST.Status, rs.DAST.Status, rs.SCA.Status}},
 	}
-	tableWriter(releaseCriteriaRows...)
+	TableWriter(releaseCriteriaRows...)
 
 	sast, err := cmd.Flags().GetBool("sast")
 	if err != nil {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -316,7 +316,7 @@ func waitTillScanEnded(cmd *cobra.Command, c *client.Client, eventID string) {
 
 				if err = passTests(scan, cmd); err != nil {
 					qwe(1, err, "scan could not pass security tests")
-				} else if err = checkRelease(scan, cmd); err != nil {
+				} else if err = checkRelease(scan); err != nil {
 					qwe(1, err, "scan failed to pass release criteria")
 				}
 				qwm(0, "scan passed security tests successfully")
@@ -624,7 +624,7 @@ func scanByImage(cmd *cobra.Command, c *client.Client) (string, error) {
 	return eventID, nil
 }
 
-func checkRelease(scan *client.ScanDetail, cmd *cobra.Command) error {
+func checkRelease(scan *client.ScanDetail) error {
 	c, err := client.New()
 	if err != nil {
 		return err

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -83,7 +83,7 @@ func scanRootCommand(cmd *cobra.Command, _ []string) {
 			{Columns: []string{"--------"}},
 			{Columns: []string{eventID}},
 		}
-		tableWriter(eventRows...)
+		TableWriter(eventRows...)
 		qwm(0, "scan has been started with async parameter, exiting.")
 	}
 
@@ -654,5 +654,5 @@ func printScanSummary(scan *client.ScanDetail) {
 		{Columns: []string{name, id, branch, meta, tool, crit, high, med, low, score, date}},
 	}
 
-	tableWriter(scanSummaryRows...)
+	TableWriter(scanSummaryRows...)
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -171,6 +171,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 }
 
 func checkForRescanOnlyTool(cmd *cobra.Command, c *client.Client) (bool, *client.ScannerInfo, error) {
+	klog.Debugf("checking for rescan only tools")
 	name, err := cmd.Flags().GetString("tool")
 	if err != nil || name == "" {
 		return false, nil, errors.New("missing require tool flag")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -128,7 +128,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		eventID, err := c.StartScanByScanId(scanID)
+		eventID, err := c.RestartScanByScanID(scanID)
 		if err != nil {
 			return "", err
 		}
@@ -146,7 +146,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 		}
 
 		if found {
-			eventID, err := c.StartScanByScanId(scanID)
+			eventID, err := c.RestartScanByScanID(scanID)
 			if err != nil {
 				return "", err
 			}
@@ -175,7 +175,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 			return "", err
 		}
 		if found {
-			eventID, err := c.StartScanByOption(scanID, opt)
+			eventID, err := c.RestartScanWithOption(scanID, opt)
 			if err != nil {
 				qwe(1, err, "could not start scan")
 			}
@@ -204,7 +204,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		eventID, err := c.StartScanByScanId(scanID)
+		eventID, err := c.RestartScanByScanID(scanID)
 		if err != nil {
 			qwe(1, err, "could not start scan")
 		}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -656,9 +656,9 @@ func printScanSummary(scan *client.ScanDetail) {
 	name, id, branch, meta, tool, date := scan.Name, scan.ID, scan.Branch, scan.MetaData, scan.Tool, scan.Date.String()
 	crit, high, med, low, score := strC(s.Critical), strC(s.High), strC(s.Medium), strC(s.Low), strC(scan.Score)
 	scanSummaryRows := []Row{
-		{Columns: []string{"NAME", "ID", "BRANCH", "META", "TOOL", "CRIT", "HIGH", "MED", "LOW", "SCORE", "DATE"}},
-		{Columns: []string{"----", "--", "------", "----", "----", "----", "----", "---", "---", "-----", "----"}},
-		{Columns: []string{name, id, branch, meta, tool, crit, high, med, low, score, date}},
+		{Columns: []string{"NAME", "ID", "BRANCH", "META", "TOOL", "CRIT", "HIGH", "MED", "LOW", "SCORE", "DATE", "UI Link"}},
+		{Columns: []string{"----", "--", "------", "----", "----", "----", "----", "---", "---", "-----", "----", "-------"}},
+		{Columns: []string{name, id, branch, meta, tool, crit, high, med, low, score, date, scan.Links.HTML}},
 	}
 
 	TableWriter(scanSummaryRows...)

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -251,7 +251,13 @@ func waitTillScanEnded(cmd *cobra.Command, c *client.Client, eventID string) {
 
 		switch event.Active {
 		case eventFailed:
-			qwm(1, "scan failed")
+			eventRows := []Row{
+				{Columns: []string{"EventID", "Event Status", "UI Link"}},
+				{Columns: []string{"-------", "------------", "-------"}},
+				{Columns: []string{event.ID, "Failed", event.Links.HTML}},
+			}
+			TableWriter(eventRows...)
+			qwm(1, fmt.Sprintf("Scan failed. Reason: %s", event.Message))
 		case eventInactive:
 			if event.Status == jobFinished {
 				klog.Println("scan finished successfully")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -418,11 +418,6 @@ func startScanByProjectTool(cmd *cobra.Command, c *client.Client) (string, error
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
 	}
-
-	if !c.IsValidTool(tool) {
-		return "", fmt.Errorf("invalid or inactive tool name: %s", tool)
-	}
-
 	branch, err := cmd.Flags().GetString("branch")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse branch flag: %w", err)
@@ -489,11 +484,6 @@ func getScanIDByProjectToolAndMeta(cmd *cobra.Command, c *client.Client) (string
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
 	}
-
-	if !c.IsValidTool(tool) {
-		return "", fmt.Errorf("invalid or inactive tool name: %s", tool)
-	}
-
 	meta, err := cmd.Flags().GetString("meta")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
@@ -534,11 +524,6 @@ func findScanIDByProjectToolAndPR(cmd *cobra.Command, c *client.Client) (string,
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
 	}
-
-	if !c.IsValidTool(tool) {
-		return "", fmt.Errorf("invalid or inactive tool name: %s", tool)
-	}
-
 	branch, err := cmd.Flags().GetString("branch")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
@@ -624,9 +609,6 @@ func scanByImage(cmd *cobra.Command, c *client.Client) (string, error) {
 	tool, err := cmd.Flags().GetString("tool")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse tool flag: %w", err)
-	}
-	if !c.IsValidTool(tool) {
-		return "", fmt.Errorf("invalid or inactive tool name: %s", tool)
 	}
 	branch, err := cmd.Flags().GetString("branch")
 	if err != nil {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -153,6 +153,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 			return eventID, nil
 		}
 
+		klog.Printf("no found completed scan by given parameters, creating a new scan")
 		branch, _ := cmd.Flags().GetString("branch")
 		project, _ := cmd.Flags().GetString("project")
 		return c.CreateNewScan(&client.Scan{

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -136,7 +136,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 		}
 		return eventID, nil
 	case modeByProjectTool:
-		required, scanner, err := isScanIDRequire(cmd, c)
+		required, scanner, err := checkForRescanOnlyTool(cmd, c)
 		if err != nil {
 			return "", err
 		}
@@ -167,7 +167,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 		})
 
 	case modeByProjectToolAndPR:
-		required, scanner, err := isScanIDRequire(cmd, c)
+		required, scanner, err := checkForRescanOnlyTool(cmd, c)
 		if err != nil {
 			return "", err
 		}
@@ -222,7 +222,7 @@ func startScan(cmd *cobra.Command, c *client.Client) (string, error) {
 	}
 }
 
-func isScanIDRequire(cmd *cobra.Command, c *client.Client) (bool, *client.ScannerInfo, error) {
+func checkForRescanOnlyTool(cmd *cobra.Command, c *client.Client) (bool, *client.ScannerInfo, error) {
 	name, err := cmd.Flags().GetString("tool")
 	if err != nil || name == "" {
 		return false, nil, errors.New("missing require tool flag")
@@ -232,7 +232,7 @@ func isScanIDRequire(cmd *cobra.Command, c *client.Client) (bool, *client.Scanne
 		return false, nil, fmt.Errorf("failed to get active scanners: %w", err)
 	}
 	if scanners.Total == 0 {
-		return false, nil, errors.New("invalid or inactive scanner tool name")
+		return false, nil, fmt.Errorf("invalid or inactive scanner tool name: %s", name)
 	}
 	scanner := scanners.ActiveScanners[0]
 	for _, label := range scanner.Labels {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -69,7 +69,7 @@ func statusRootCommand(cmd *cobra.Command, _ []string) {
 		{Columns: []string{"----", "--", "----", "----", "----", "----", "---", "---", "-----", "----"}},
 		{Columns: []string{name, id, meta, tool, crit, high, med, low, score, date}},
 	}
-	tableWriter(scanSummaryRows...)
+	TableWriter(scanSummaryRows...)
 
 	if err = passTests(scan, cmd); err != nil {
 		qwe(1, err, "scan could not pass security tests")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -33,7 +33,7 @@ type Row struct {
 	Columns []string
 }
 
-func tableWriter(rows ...Row) {
+func TableWriter(rows ...Row) {
 	w := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
 	for _, row := range rows {
 		var r string

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -14,31 +14,6 @@ import (
 	"github.com/kondukto-io/kdt/klog"
 )
 
-var scanners = map[string]string{
-	"checkmarx":           "sast",
-	"checkmarxsca":        "sca",
-	"checkmarxkics":       "iac",
-	"owaspzap":            "dast",
-	"webinspect":          "dast",
-	"netsparker":          "dast",
-	"appspider":           "dast",
-	"bandit":              "sast",
-	"findsecbugs":         "sast",
-	"gosec":               "sast",
-	"dependencycheck":     "sca",
-	"fortify":             "sast",
-	"securitycodescan":    "sast",
-	"hclappscan":          "dast",
-	"veracode":            "sast",
-	"burpsuite":           "dast",
-	"burpsuiteenterprise": "dast",
-	"nuclei":              "dast",
-	"gitleaks":            "sast",
-	"semgrep":             "sast",
-	"semgrepconfig":       "iac",
-	"trivy":               "cs",
-}
-
 // qwe quits with error. If there are messages, wraps error with message
 func qwe(code int, err error, messages ...string) {
 	for _, m := range messages {
@@ -52,13 +27,6 @@ func qwe(code int, err error, messages ...string) {
 func qwm(code int, message string) {
 	klog.Println(message)
 	os.Exit(code)
-}
-
-func validTool(t string) bool {
-	if _, ok := scanners[t]; ok {
-		return true
-	}
-	return false
 }
 
 type Row struct {


### PR DESCRIPTION
### This pr includes several features and improvements:
* The scanner list from now on is showing the active scanners list as dynamically.
* Scanners have labels that define scanner can be triggered as a new scan or not.
* Projects List, Scan status, and Failed scans have UI Links that direct to kondukto UI.
* Adds detailed log for failed cases.
---
Fixes #42 