### PR TITLE
Pass parameters when fork-scan enabled

### DIFF
--- a/client/scanners.go
+++ b/client/scanners.go
@@ -149,7 +149,11 @@ func (c *Client) IsValidTool(tool string) bool {
 }
 
 // IsRescanOnlyLabel returns true if the given label is a rescan only label
-func IsRescanOnlyLabel(label string) bool {
+// If fork scan is true, then the ScannerLabelTemplate label is not a rescan only label, it can be used for fork scan
+func IsRescanOnlyLabel(label string, isForkScan bool) bool {
+	if isForkScan && label == ScannerLabelTemplate {
+		return false
+	}
 	if label == ScannerLabelBind || label == ScannerLabelAgent || label == ScannerLabelTemplate {
 		return true
 	}

--- a/client/scanners.go
+++ b/client/scanners.go
@@ -151,7 +151,7 @@ func (c *Client) IsValidTool(tool string) bool {
 // IsRescanOnlyLabel returns true if the given label is a rescan only label
 // If fork scan is true, then the ScannerLabelTemplate label is not a rescan only label, it can be used for fork scan
 func IsRescanOnlyLabel(label string, isForkScan bool) bool {
-	if isForkScan && label == ScannerLabelTemplate {
+	if isForkScan {
 		return false
 	}
 	if label == ScannerLabelBind || label == ScannerLabelAgent || label == ScannerLabelTemplate {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -850,13 +850,19 @@ func (s *Scan) findScanIDByProjectToolAndForkScan() (string, error) {
 			klog.Debugf("scanner tool %s is only allowing rescans", tool)
 			klog.Fatal("no scans found for given project, tool and PR configuration")
 		}
+
+		var custom = client.Custom{Type: scanner.CustomType}
+		if s.cmd.Flags().Changed("params") {
+			custom = s.parseCustomParams(custom, *scanner)
+		}
+
 		return &client.Scan{
 			Branch:   branch,
 			MetaData: meta,
 			Project:  project.Name,
 			ForkScan: forkScan,
 			ToolID:   scanner.ID,
-			Custom:   client.Custom{Type: scanner.CustomType},
+			Custom:   custom,
 		}
 	}()
 
@@ -885,8 +891,13 @@ func (s *Scan) checkForRescanOnlyTool() (bool, *client.ScannerInfo, error) {
 		return false, scanner, nil
 	}
 
+	isForkScan, err := s.cmd.Flags().GetBool("fork-scan")
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get fork-scan flag: %w", err)
+	}
+
 	for _, label := range scanner.Labels {
-		if client.IsRescanOnlyLabel(label) {
+		if client.IsRescanOnlyLabel(label, isForkScan) {
 			return true, scanner, nil
 		}
 	}


### PR DESCRIPTION
This PR fixes this problem : https://github.com/endpointlabs/twrap-go/issues/1757

In summary, when you trigger a forkscan via KDT, it isn't possible because KDT doesn't send the passed cmd params to kondukto. With this PR, I fixed this problem. 🎉 