### PR TITLE
Pass scanparam fields to the available scanparam

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -842,21 +842,12 @@ func (s *Scan) findScanIDByProjectToolAndForkScan() (string, error) {
 	}
 
 	var scanData = func() *client.Scan {
-		if sp != nil {
-			return &client.Scan{ScanparamsID: sp.ID}
-		}
-
-		if rescanOnly {
-			klog.Debugf("scanner tool %s is only allowing rescans", tool)
-			klog.Fatal("no scans found for given project, tool and PR configuration")
-		}
-
 		var custom = client.Custom{Type: scanner.CustomType}
 		if s.cmd.Flags().Changed("params") {
 			custom = s.parseCustomParams(custom, *scanner)
 		}
 
-		return &client.Scan{
+		var scanPayload = &client.Scan{
 			Branch:   branch,
 			MetaData: meta,
 			Project:  project.Name,
@@ -864,6 +855,18 @@ func (s *Scan) findScanIDByProjectToolAndForkScan() (string, error) {
 			ToolID:   scanner.ID,
 			Custom:   custom,
 		}
+
+		if sp != nil {
+			scanPayload.ScanparamsID = sp.ID
+			return scanPayload
+		}
+
+		if rescanOnly {
+			klog.Debugf("scanner tool %s is only allowing rescans", tool)
+			klog.Fatal("no scans found for given project, tool and PR configuration")
+		}
+
+		return scanPayload
 	}()
 
 	return s.client.CreateNewScan(scanData)


### PR DESCRIPTION
This PR fixes this problem : https://github.com/endpointlabs/twrap-go/issues/1807

In past latest KDT version named as v1.0.21.4
The customer was use this version and tried to create fork scan.
This operation created scan parameter with empty parameters on their system (And this scan param is not reliable to use).

I fixed the empty scan parameter fields problem on v1.0.21.5 on KDT.
But old scan parameter still their on system.

With this PR, KDT will override fields (like `custom`, `branch` etc.) to old scan parameter.