### PR TITLE
Add overwrite feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ kdt --config kondukto-config.yml \
 - --alm-tool: If there is more than one ALM enabled in Kondukto you need to specify ALM tool, otherwise it is not necessary.
 - --team: Specify a team name. By default team name is `default team`. 
 - --force-create: Create a project with prefix `-` if there is another project with the same name.
-- --over-write: Overwrite project name, there is no need to add `-` prefix.
+- --overwrite: Overwrite project name, there is no need to add `-` prefix.
 
 This command will create a project on Kondukto with the same name in your ALM(Application Lifecycle Management) tool. If there is another project
-with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to create a project with a prefix `-` or you can pass `--over-write` flag to overwrite the project name.
+with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to create a project with a prefix `-` or you can pass `--overwrite` flag to overwrite the project name.
 
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ kdt --config kondukto-config.yml \
 - --labels: Associate project with a label list
 - --alm-tool: If there is more than one ALM enabled in Kondukto you need to specify ALM tool, otherwise it is not necessary.
 - --team: Specify a team name. By default team name is `default team`. 
-- --force-create: Create a project with prefix `-` if there is another project with the same name.
-- --overwrite: Overwrite project name, there is no need to add `-` prefix.
+- --force-create: Create a project with suffix `-` if there is another project with the same name.
+- --overwrite: Overwrite project name, there is no need to add `-` suffix.
 
 This command will create a project on Kondukto with the same name in your ALM(Application Lifecycle Management) tool. If there is another project
-with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to create a project with a prefix `-` or you can pass `--overwrite` flag to overwrite the project name.
+with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to create a project with a suffix `-` or you can pass `--overwrite` flag to overwrite the project name.
 
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,13 @@ kdt --config kondukto-config.yml \
 - --labels: Associate project with a label list
 - --alm-tool: If there is more than one ALM enabled in Kondukto you need to specify ALM tool, otherwise it is not necessary.
 - --team: Specify a team name. By default team name is `default team`. 
+- --force-create: Create a project with prefix `-` if there is another project with the same name.
+- --over-write: Overwrite project name, there is no need to add `-` prefix.
 
 This command will create a project on Kondukto with the same name in your ALM(Application Lifecycle Management) tool. If there is another project
-with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to overwrite this behaviour.
+with the same name, command will print an error message and exit with a status code. You can pass `--force-create` flag to create a project with a prefix `-` or you can pass `--over-write` flag to overwrite the project name.
+
+``` 
 
 ## Contributing to KDT
 If you wish to get involved in KDT development, create issues for problems and missing features or fork the repository and create pull requests to help the development directly.

--- a/client/projects.go
+++ b/client/projects.go
@@ -94,7 +94,7 @@ type ProjectDetail struct {
 	Source    ProjectSource  `json:"source"`
 	Team      ProjectTeam    `json:"team"`
 	Labels    []ProjectLabel `json:"labels"`
-	Override  bool           `json:"override"`  // That means, if the project already exists, create a new one with prefix "-"
+	Override  bool           `json:"override"`  // That means, if the project already exists, create a new one with suffix "-"
 	Overwrite bool           `json:"overwrite"` // That means, if the project already exists, overwrite it
 }
 

--- a/client/projects.go
+++ b/client/projects.go
@@ -90,10 +90,12 @@ func (c *Client) FindProjectByName(name string) (*Project, error) {
 }
 
 type ProjectDetail struct {
-	Source   ProjectSource  `json:"source"`
-	Team     ProjectTeam    `json:"team"`
-	Labels   []ProjectLabel `json:"labels"`
-	Override bool           `json:"override"`
+	Name      string         `json:"name"`
+	Source    ProjectSource  `json:"source"`
+	Team      ProjectTeam    `json:"team"`
+	Labels    []ProjectLabel `json:"labels"`
+	Override  bool           `json:"override"`  // That means, if the project already exists, create a new one with prefix "-"
+	Overwrite bool           `json:"overwrite"` // That means, if the project already exists, overwrite it
 }
 
 type ProjectSource struct {

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kondukto-io/kdt/client"
 	"github.com/kondukto-io/kdt/klog"
+
 	"github.com/spf13/cobra"
 )
 
@@ -210,19 +211,21 @@ func (p *Project) checkProjectIfExist(repositoryID string, force bool, overwrite
 		isOverwrite = true
 	}
 
-	if !force && !isOverwrite {
-		projects, err := p.client.ListProjects("", repositoryID)
-		if err != nil {
-			qwe(ExitCodeError, err, "failed to check project with alm info")
-		}
+	if force || isOverwrite {
+		return
+	}
 
-		if len(projects) > 0 {
-			for _, project := range projects {
-				p.printRows = append(p.printRows, Row{Columns: project.FieldsAsRow()})
-			}
-			TableWriter(p.printRows...)
-			qwm(ExitCodeError, fmt.Sprintf("%d project(s) with the same repo-id already exists. for force creation pass --force-create flag or rename project with --overwrite flag", len(projects)))
+	projects, err := p.client.ListProjects("", repositoryID)
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to check project with alm info")
+	}
+
+	if len(projects) > 0 {
+		for _, project := range projects {
+			p.printRows = append(p.printRows, Row{Columns: project.FieldsAsRow()})
 		}
+		TableWriter(p.printRows...)
+		qwm(ExitCodeError, fmt.Sprintf("%d project(s) with the same repo-id already exists. for force creation pass --force-create flag or rename project with --overwrite flag", len(projects)))
 	}
 }
 

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -71,7 +71,7 @@ func createProjectsRootCommand(cmd *cobra.Command, _ []string) {
 		qwe(ExitCodeError, err, "failed to parse the overwrite flag: %v")
 	}
 
-	p.overwriteOrForce(force, overwrite) // Being over write or being force create. That is the question. :)
+	p.overwriteOrForce(force, overwrite) // Check if overwrite and force flags are used together.
 
 	p.checkProjectIfExist(repositoryID, force, overwrite) // Check if the project already exists.
 

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -26,7 +26,7 @@ func init() {
 	createCmd.AddCommand(createProjectCmd)
 
 	createProjectCmd.Flags().Bool("force-create", false, "ignore if the URL is used by another Kondukto project")
-	createProjectCmd.Flags().StringP("over-write", "w", "", "rename the project name when creating a new project")
+	createProjectCmd.Flags().StringP("overwrite", "w", "", "rename the project name when creating a new project")
 	createProjectCmd.Flags().StringP("labels", "l", "", "comma separated label names")
 	createProjectCmd.Flags().StringP("team", "t", "", "project team name")
 	createProjectCmd.Flags().String("repo-id", "r", "URL or ID of ALM repository")
@@ -66,9 +66,9 @@ func createProjectsRootCommand(cmd *cobra.Command, _ []string) {
 		qwm(ExitCodeError, fmt.Sprintf("failed to parse the force-create flag: %v", err))
 	}
 
-	overwrite, err := p.cmd.Flags().GetString("over-write")
+	overwrite, err := p.cmd.Flags().GetString("overwrite")
 	if err != nil {
-		qwe(ExitCodeError, err, "failed to parse the over-write flag: %v")
+		qwe(ExitCodeError, err, "failed to parse the overwrite flag: %v")
 	}
 
 	p.overwriteOrForce(force, overwrite) // Being over write or being force create. That is the question. :)
@@ -200,7 +200,7 @@ func (p *Project) overwriteOrForce(force bool, overwrite string) {
 	}
 
 	if force && isOverWrite {
-		qwm(ExitCodeError, "please select either the --force-create or --over-write flag, but not both, to create a project.")
+		qwm(ExitCodeError, "please select either the --force-create or --overwrite flag, but not both, to create a project.")
 	}
 }
 
@@ -221,7 +221,7 @@ func (p *Project) checkProjectIfExist(repositoryID string, force bool, overwrite
 				p.printRows = append(p.printRows, Row{Columns: project.FieldsAsRow()})
 			}
 			TableWriter(p.printRows...)
-			qwm(ExitCodeError, fmt.Sprintf("%d project(s) with the same repo-id already exists. for force creation pass --force-create flag or rename project with --over-write flag", len(projects)))
+			qwm(ExitCodeError, fmt.Sprintf("%d project(s) with the same repo-id already exists. for force creation pass --force-create flag or rename project with --overwrite flag", len(projects)))
 		}
 	}
 }


### PR DESCRIPTION
Fixes : https://github.com/endpointlabs/kondukto-ui-vue/issues/2032

Basically, you can overwrite project name when create a project via kdt.