### PR TITLE
Create team via kdt

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2023 Kondukto
+
+*/
+
+package client
+
+import "net/http"
+
+type Team struct {
+	Name             string           `json:"name"`
+	IssueResponsible IssueResponsible `json:"issue_responsible"`
+}
+
+type IssueResponsible struct {
+	Username string `json:"username"`
+}
+
+func (c *Client) CreateTeam(teamName, responsible string) error {
+	var team = Team{
+		Name: teamName,
+		IssueResponsible: IssueResponsible{
+			Username: responsible,
+		},
+	}
+
+	req, err := c.newRequest(http.MethodPost, "/api/v3/teams", team)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/createTeam.go
+++ b/cmd/createTeam.go
@@ -1,3 +1,8 @@
+/*
+Copyright © 2023 Kondukto
+
+*/
+
 package cmd
 
 import (

--- a/cmd/createTeam.go
+++ b/cmd/createTeam.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kondukto-io/kdt/client"
+
+	"github.com/spf13/cobra"
+)
+
+// createTeamCmd represents the create project command
+var createTeamCmd = &cobra.Command{
+	Use:   "team",
+	Short: "creates a new team on Kondukto",
+	Run:   createTeamRootCommand,
+}
+
+func init() {
+	createCmd.AddCommand(createTeamCmd)
+
+	createTeamCmd.Flags().StringP("name", "n", "", "team name")
+	createTeamCmd.Flags().StringP("responsible", "r", "", "responsible user name")
+}
+
+func createTeamRootCommand(cmd *cobra.Command, _ []string) {
+	c, err := client.New()
+	if err != nil {
+		qwe(ExitCodeError, err, "could not initialize Kondukto client")
+	}
+
+	teamName, err := cmd.Flags().GetString("name")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse the name flag")
+	}
+
+	responsible, err := cmd.Flags().GetString("responsible")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse the responsible flag")
+	}
+
+	if teamName == "" {
+		qwm(ExitCodeError, "team name is required")
+	}
+
+	if err := c.CreateTeam(teamName, responsible); err != nil {
+		qwe(ExitCodeError, err, "failed to create team")
+	}
+
+	var successfulMessage string
+	if responsible != "" {
+		successfulMessage = fmt.Sprintf("team [%s] created successfuly with responsible [%s]", teamName, responsible)
+	} else {
+		successfulMessage = fmt.Sprintf("team [%s] created successfuly with responsible [admin]", teamName)
+	}
+
+	qwm(ExitCodeSuccess, successfulMessage)
+}


### PR DESCRIPTION
https://github.com/endpointlabs/twrap-go/issues/2141

You can create team via kdt.
example usage:

Create team without responsible (uses admin as responsible)
`kdt create team -n newTeamName`

Create team with responsible
`kdt create team -n NewTeamName -r responsibleUser`