### PR TITLE
Add the branch field to get branch specific release criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ The following flags are specific to the release commands:
 
 - `-p` or `--project`: Specifies the project name or ID.
 
+- `-b` or `--branch`: Specifies the project branch name, default is the project's default branch.
+
 - `--cs`: Processes CS (Code Security) criteria status.
 
 - `--dast`: Processes DAST (Dynamic Application Security Testing) criteria status.

--- a/client/projects.go
+++ b/client/projects.go
@@ -157,13 +157,16 @@ func (c *Client) ReleaseStatus(project, branch string) (*ReleaseStatus, error) {
 	}
 
 	path := fmt.Sprintf("/api/v1/projects/%s/release", project)
-	if branch != "" {
-		path += fmt.Sprintf("?branch=%s", branch)
-	}
 
 	req, err := c.newRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if branch != "" {
+		queryParams := req.URL.Query()
+		queryParams.Add("branch", branch)
+		req.URL.RawQuery = queryParams.Encode()
 	}
 
 	rs := new(ReleaseStatus)

--- a/client/projects.go
+++ b/client/projects.go
@@ -151,12 +151,15 @@ type PlaybookTypeDetail struct {
 	ScanID string `json:"scan_id,omitempty" bson:"scan_id"`
 }
 
-func (c *Client) ReleaseStatus(project string) (*ReleaseStatus, error) {
+func (c *Client) ReleaseStatus(project, branch string) (*ReleaseStatus, error) {
 	if project == "" {
 		return nil, errors.New("missing project id or name")
 	}
 
 	path := fmt.Sprintf("/api/v1/projects/%s/release", project)
+	if branch != "" {
+		path += fmt.Sprintf("?branch=%s", branch)
+	}
 
 	req, err := c.newRequest("GET", path, nil)
 	if err != nil {

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.AddCommand(releaseCmd)
 
 	releaseCmd.Flags().StringP("project", "p", "", "project name or id")
+	releaseCmd.Flags().StringP("branch", "b", "", "project branch name, default is the project's default branch")
 	releaseCmd.Flags().Bool("sast", false, "sast criteria status")
 	releaseCmd.Flags().Bool("dast", false, "dast criteria status")
 	releaseCmd.Flags().Bool("pentest", false, "pentest criteria status")
@@ -47,7 +48,12 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		qwe(ExitCodeError, err, "failed to parse project flag")
 	}
 
-	rs, err := c.ReleaseStatus(project)
+	branch, err := getSanitizedFlagStr(cmd, "branch")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse branch flag")
+	}
+
+	rs, err := c.ReleaseStatus(project, branch)
 	if err != nil {
 		qwe(ExitCodeError, fmt.Errorf("failed to get release status: %w", err))
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1100,7 +1100,7 @@ func checkRelease(scan *client.ScanDetail, cmd *cobra.Command) error {
 		return err
 	}
 
-	rs, err := c.ReleaseStatus(scan.Project)
+	rs, err := c.ReleaseStatus(scan.Project, scan.Branch)
 	if err != nil {
 		return fmt.Errorf("failed to get release status: %w", err)
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,6 +23,7 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 
 	statusCmd.Flags().StringP("project", "p", "", "project name or id")
+	statusCmd.Flags().StringP("branch", "b", "", "project branch name, default is the branch of the latest completed scan")
 	statusCmd.Flags().Bool("threshold-risk", false, "set risk score of last scan as threshold")
 	statusCmd.Flags().Int("threshold-crit", 0, "threshold for number of vulnerabilities with critical severity")
 	statusCmd.Flags().Int("threshold-high", 0, "threshold for number of vulnerabilities with high severity")
@@ -37,8 +38,14 @@ func statusRootCommand(cmd *cobra.Command, _ []string) {
 		qwe(ExitCodeError, err, "could not initialize Kondukto client")
 	}
 
-	pid := cmd.Flag("project").Value.String()
-	scans, err := c.ListScans(pid, nil)
+	var pid = cmd.Flag("project").Value.String()
+
+	var scanSearchParams *client.ScanSearchParams
+	if branch := cmd.Flag("branch").Value.String(); branch != "" {
+		scanSearchParams = &client.ScanSearchParams{Branch: branch}
+	}
+
+	scans, err := c.ListScans(pid, scanSearchParams)
 	if err != nil {
 		qwe(ExitCodeError, err, "could not retrieve scans of the project")
 	}


### PR DESCRIPTION
The new Kondukto policy service needs a branch value to calculate the release criteria status.
So, this PR adds a new branch flag to the `release` command.