### PR TITLE
Remove omitempty of metadata

### DIFF
--- a/client/scans.go
+++ b/client/scans.go
@@ -44,7 +44,7 @@ type (
 	ScanSearchParams struct {
 		Branch   string `url:"branch,omitempty"`
 		Tool     string `url:"tool,omitempty"`
-		MetaData string `url:"meta_data,omitempty"`
+		MetaData string `url:"meta_data"`
 		PR       bool   `url:"pr"`
 		Manual   bool   `url:"manual"`
 		AgentID  string `url:"agent_id"`


### PR DESCRIPTION
We need to apply metaData = "" filter on kondukto, but when its omit empty we are not able to distinguish if it "" or empty.

Twrap PR: https://github.com/endpointlabs/twrap-go/pull/2850