### PR TITLE
Feature #3304: Add project scopes via KDT

### DIFF
--- a/client/projects.go
+++ b/client/projects.go
@@ -106,11 +106,19 @@ type ProjectDetail struct {
 }
 
 type ProjectSource struct {
-	Tool         string `json:"tool"`
-	ID           string `json:"id"`
-	URL          string `json:"url"`
-	CloneEnabled bool   `json:"clone_enabled"`
+	Tool         string    `json:"tool"`
+	ID           string    `json:"id"`
+	URL          string    `json:"url"`
+	CloneEnabled bool      `json:"clone_enabled"`
+	PathScope    PathScope `json:"path_scope"`
 }
+
+type PathScope struct {
+	IncludeEmpty  bool   `json:"include_empty"`
+	IncludedPaths string `json:"included_paths"`
+	IncludedFiles string `json:"included_files"`
+}
+
 type ProjectTeam struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name"`

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -39,7 +39,7 @@ func init() {
 	createProjectCmd.Flags().Bool("feature-branch-infinite-retention", false, "Sets an infinite retention for project feature branches. Overrides --feature-branch-retention flag when set to true.")
 	createProjectCmd.Flags().String("default-branch", "main", "sets the default branch for the project. When repo-id is given, this will be overridden by the repository's default branch.")
 	createProjectCmd.Flags().Bool("scope-include-empty", false, "enable to include SAST, SCA and IAC vulnerabilities with no path in this project.")
-	createProjectCmd.Flags().String("scope-included-pathes", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
+	createProjectCmd.Flags().String("scope-included-paths", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
 	createProjectCmd.Flags().String("scope-included-files", "", "a comma separated list of file names Kondukto should check for in vulnerabilities alongside paths")
 }
 
@@ -172,9 +172,9 @@ func (p *Project) createProject(repo string, force bool, overwrite ...string) *c
 		qwe(ExitCodeError, err, "failed to parse the scope-include-empty flag")
 	}
 
-	scopeIncludedPaths, err := p.cmd.Flags().GetString("scope-included-pathes")
+	scopeIncludedPaths, err := p.cmd.Flags().GetString("scope-included-paths")
 	if err != nil {
-		qwe(ExitCodeError, err, "failed to parse the scope-included-pathes flag")
+		qwe(ExitCodeError, err, "failed to parse the scope-included-paths flag")
 	}
 
 	scopeIncludedFiles, err := p.cmd.Flags().GetString("scope-included-files")

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -37,7 +37,10 @@ func init() {
 	createProjectCmd.Flags().String("fork-source", "", "Sets the source branch of project's feature branches to be forked from.")
 	createProjectCmd.Flags().Uint("feature-branch-retention", 0, "Adds a retention(days) period to the project for feature branch delete operations.")
 	createProjectCmd.Flags().Bool("feature-branch-infinite-retention", false, "Sets an infinite retention for project feature branches. Overrides --feature-branch-retention flag when set to true.")
-	createProjectCmd.Flags().String("default-branch", "main", "Sets the default branch for the project. When repo-id is given, this will be overridden by the repository's default branch.")
+	createProjectCmd.Flags().String("default-branch", "main", "sets the default branch for the project. When repo-id is given, this will be overridden by the repository's default branch.")
+	createProjectCmd.Flags().Bool("scope-include-empty", false, "enable to include SAST, SCA and IAC vulnerabilities with no path in this project.")
+	createProjectCmd.Flags().String("scope-included-pathes", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
+	createProjectCmd.Flags().String("scope-included-files", "", "a comma separated list of file names Kondukto should check for in vulnerabilities alongside paths")
 }
 
 type Project struct {
@@ -164,6 +167,21 @@ func (p *Project) createProject(repo string, force bool, overwrite ...string) *c
 		qwe(ExitCodeError, err, "failed to parse the enable-clone flag")
 	}
 
+	scopeAllowEmpty, err := p.cmd.Flags().GetBool("scope-include-empty")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse the scope-include-empty flag")
+	}
+
+	scopeIncludedPaths, err := p.cmd.Flags().GetString("scope-included-pathes")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse the scope-included-pathes flag")
+	}
+
+	scopeIncludedFiles, err := p.cmd.Flags().GetString("scope-included-files")
+	if err != nil {
+		qwe(ExitCodeError, err, "failed to parse the scope-included-files flag")
+	}
+
 	projectSource := func() client.ProjectSource {
 		s := client.ProjectSource{Tool: tool}
 		u, err := url.Parse(repo)
@@ -173,6 +191,17 @@ func (p *Project) createProject(repo string, force bool, overwrite ...string) *c
 			s.URL = repo
 		}
 		s.CloneEnabled = enableCloneOperation
+
+		if scopeIncludedPaths == "" && scopeIncludedFiles == "" {
+			return s
+		}
+
+		s.PathScope = client.PathScope{
+			IncludeEmpty:  scopeAllowEmpty,
+			IncludedPaths: scopeIncludedPaths,
+			IncludedFiles: scopeIncludedFiles,
+		}
+
 		return s
 	}()
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -83,7 +83,7 @@ func init() {
 	scanCmd.Flags().Bool("feature-branch-infinite-retention", false, "Sets an infinite retention for project feature branches. Overrides --feature-branch-retention flag when set to true [create-project]")
 	scanCmd.Flags().String("default-branch", "main", "Sets the default branch for the project. When repo-id is given, this will be overridden by the repository's default branch [create-project].")
 	scanCmd.Flags().Bool("scope-allow-empty", false, "enable to include SAST, SCA and IAC vulnerabilities with no path in this project.")
-	scanCmd.Flags().String("scope-included-pathes", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
+	scanCmd.Flags().String("scope-included-paths", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
 	scanCmd.Flags().String("scope-included-files", "", "a comma separated list of file names Kondukto should check for in vulnerabilities alongside paths")
 
 	scanCmd.Flags().Bool("threshold-risk", false, "set risk score of last scan as threshold")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -82,6 +82,9 @@ func init() {
 	scanCmd.Flags().Uint("feature-branch-retention", 0, "Adds a retention(days) to the project for feature branch delete operations [create-project]")
 	scanCmd.Flags().Bool("feature-branch-infinite-retention", false, "Sets an infinite retention for project feature branches. Overrides --feature-branch-retention flag when set to true [create-project]")
 	scanCmd.Flags().String("default-branch", "main", "Sets the default branch for the project. When repo-id is given, this will be overridden by the repository's default branch [create-project].")
+	scanCmd.Flags().Bool("scope-allow-empty", false, "enable to include SAST, SCA and IAC vulnerabilities with no path in this project.")
+	scanCmd.Flags().String("scope-included-pathes", "", "a comma separated list of paths within your mono-repo so that Kondukto can decide on the SAST, SCA and IAC vulnerabilities to include in this project.")
+	scanCmd.Flags().String("scope-included-files", "", "a comma separated list of file names Kondukto should check for in vulnerabilities alongside paths")
 
 	scanCmd.Flags().Bool("threshold-risk", false, "set risk score of last scan as threshold")
 	scanCmd.Flags().Int("threshold-crit", 0, "threshold for number of vulnerabilities with critical severity")


### PR DESCRIPTION
Adds 3 new flags to set project scope configuration on the project create operations.
Here is an example:
```shell
./kdt create project --repo-id "https://github.com/kondukto-io/kdt" --alm-tool github -t default --labels Internal --scope-include-empty --scope-included-pathes   "internal/pkg,cmd,client" --scope-included-files "main.go"
```
And it looks like the below on the Kondukto side:
<img width="1728" alt="Screenshot 2024-08-19 at 16 24 23" src="https://github.com/user-attachments/assets/9347596d-9cda-4c91-bedc-05e6d9884bec">
