### PR TITLE
feature: aarch64 support in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -71,7 +71,7 @@ getPackage() {
 
     if [ $arch = "x86_64" ]; then
 	arch="amd64"
-    elif [ $arch = "arm64" ] || [ $arch = "aarm64" ]; then
+    elif [ $arch = "arm64" ] || [ $arch = "aarch64" ] || [ $arch = "aarm64" ]; then
 	arch="arm64"
     fi
 


### PR DESCRIPTION
For Debian/Ubuntu-based distros, output of `uname -m` is `aarch64`. 

The change is tested on Ubuntu 22.04 and Ubuntu 24.04. 

When the script works, [the arm package](https://github.com/kondukto-io/kdt/releases/download/v1.0.35/kdt-linux-arm64) in the Releases page is downloaded and the package works fine. 