### PR TITLE
Feature/i3465 pr scan

### DIFF
--- a/client/scans.go
+++ b/client/scans.go
@@ -63,9 +63,11 @@ type (
 		Limit            int    `url:"limit,omitempty"`
 	}
 
-	ScanPROptions struct {
-		From               string `json:"from"`
-		To                 string `json:"to"`
+	ScanRestartOptions struct {
+		// MergeSourceBranch is source branch of the PR. It is required when PR is true
+		MergeSourceBranch string `json:"from"`
+		// MergeTargetBranch is target branch of the PR. It is required when PR is true
+		MergeTargetBranch  string `json:"to"`
 		OverrideOldAnalyze bool   `json:"override_old_analyze"`
 		PRNumber           string `json:"pr_number"`
 		NoDecoration       bool   `json:"no_decoration"`
@@ -184,7 +186,7 @@ func (c *Client) RestartScanByScanID(id string) (string, error) {
 	return rsr.Event, nil
 }
 
-func (c *Client) RestartScanWithOption(id string, opt *ScanPROptions) (string, error) {
+func (c *Client) RestartScanWithOption(id string, opt *ScanRestartOptions) (string, error) {
 	if opt == nil {
 		return "", errors.New("missing scan options")
 	}

--- a/client/scans.go
+++ b/client/scans.go
@@ -67,12 +67,13 @@ type (
 		// MergeSourceBranch is source branch of the PR. It is required when PR is true
 		MergeSourceBranch string `json:"from"`
 		// MergeTargetBranch is target branch of the PR. It is required when PR is true
-		MergeTargetBranch  string `json:"to"`
-		OverrideOldAnalyze bool   `json:"override_old_analyze"`
-		PRNumber           string `json:"pr_number"`
-		NoDecoration       bool   `json:"no_decoration"`
-		Custom             Custom `json:"custom"`
-		Environment        string `url:"environment"`
+		MergeTargetBranch        string `json:"to"`
+		OverrideOldAnalyze       bool   `json:"override_old_analyze"`
+		PRNumber                 string `json:"pr_number"`
+		NoDecoration             bool   `json:"no_decoration"`
+		PRDecorationScannerTypes string `json:"pr_decoration_scanner_types"`
+		Custom                   Custom `json:"custom"`
+		Environment              string `url:"environment"`
 	}
 
 	ResultSet struct {
@@ -128,10 +129,12 @@ type (
 	}
 
 	PRInfo struct {
-		OK           bool   `json:"ok" json:"ok"`
-		Target       string `json:"target" bson:"target" valid:"Branch"`
-		PRNumber     string `json:"pr_number"`
-		NoDecoration bool   `json:"no_decoration"`
+		// OK means that the merge target is a valid branch to merge the source branch changes into.
+		OK                       bool   `json:"ok" json:"ok"`
+		MergeTarget              string `json:"target" bson:"target" valid:"Branch"`
+		PRNumber                 string `json:"pr_number"`
+		NoDecoration             bool   `json:"no_decoration"`
+		PRDecorationScannerTypes string `json:"pr_decoration_scanner_types"`
 	}
 
 	Custom struct {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -63,7 +63,7 @@ func init() {
 	scanCmd.Flags().Bool("override", false, "overrides the old analyzed results for the source branch of the PR scan")
 	scanCmd.Flags().Bool("no-decoration", false, "disables the PR decoration of the PR scan feature. Deprecated, remove the pr-number flag to disable PR decoration")
 	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It is not triggers the PR scan, only sets the PR decoration")
-	scanCmd.Flags().StringP("pr-decoration-scanner-types", "", "", "specify the comma separated scanner types for pr decoration vulnerability summary. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
+	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify the comma separated scanner types for pr decoration vulnerability summary. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
 
 	scanCmd.Flags().StringP("image", "I", "", "image to scan with container security products")
 	scanCmd.Flags().StringP("agent", "a", "", "agent name for agent type scanners")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -62,7 +62,7 @@ func init() {
 	scanCmd.Flags().StringP("merge-target", "M", "", "target branch name for pull request scans. For more details, please visit https://docs.kondukto.io/docs/scans-page")
 	scanCmd.Flags().Bool("override", false, "overrides the old analyzed results for the source branch of the PR scan")
 	scanCmd.Flags().Bool("no-decoration", false, "disables the PR decoration of the PR scan feature. Deprecated, remove the pr-number flag to disable PR decoration")
-	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It is not triggers the PR scan, only sets the PR decoration")
+	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It does not trigger the PR scan, it only sets the PR decoration")
 	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify the comma separated scanner types for pr decoration vulnerability summary. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
 
 	scanCmd.Flags().StringP("image", "I", "", "image to scan with container security products")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -63,7 +63,7 @@ func init() {
 	scanCmd.Flags().Bool("override", false, "overrides the old analyzed results for the source branch of the PR scan")
 	scanCmd.Flags().Bool("no-decoration", false, "disables the PR decoration of the PR scan feature. Deprecated, remove the pr-number flag to disable PR decoration")
 	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It does not trigger the PR scan, it only sets the PR decoration")
-	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify comma separated scanner types for the project vulnerability summary of pr decoration. By default, it only uses the scanner type of the current scan. Example: all,sast,dast,sca...")
+	scanCmd.Flags().StringArray("pr-decoration-scanner-types", nil, "specify comma separated scanner types for the project vulnerability summary of pr decoration. By default, it only uses the scanner type of the current scan. Example: all,sast,dast,sca...")
 
 	scanCmd.Flags().StringP("image", "I", "", "image to scan with container security products")
 	scanCmd.Flags().StringP("agent", "a", "", "agent name for agent type scanners")
@@ -1208,7 +1208,7 @@ func (s *Scan) getValidatedPullRequestFields() (*client.PRInfo, bool, error) {
 }
 
 func (s *Scan) getDecorationScannerTypes() (string, error) {
-	prDecorationScannerTypes, err := s.cmd.Flags().GetStringSlice("pr-decoration-scanner-types")
+	prDecorationScannerTypes, err := s.cmd.Flags().GetStringArray("pr-decoration-scanner-types")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse pr-decoration-scanner-types flag: %w", err)
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1192,7 +1192,7 @@ func (s *Scan) getValidatedPullRequestFields() (*client.PRInfo, bool, error) {
 	if noDecoration {
 		klog.Warn("no-decoration flag is deprecated and will be removed in the future")
 		if prNumber != "" {
-			return nil, false, errors.New("no-decoration flag cannot be used with pr-number flag")
+			return nil, false, errors.New("no-decoration flag cannot be used with pr-number flag. If the pr decoration is not desired, please remove the pr-number flag")
 		}
 	}
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -63,7 +63,7 @@ func init() {
 	scanCmd.Flags().Bool("override", false, "overrides the old analyzed results for the source branch of the PR scan")
 	scanCmd.Flags().Bool("no-decoration", false, "disables the PR decoration of the PR scan feature. Deprecated, remove the pr-number flag to disable PR decoration")
 	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It does not trigger the PR scan, it only sets the PR decoration")
-	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify comma separated scanner types for the project vulnerability summary of pr decoration. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
+	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify comma separated scanner types for the project vulnerability summary of pr decoration. By default, it only uses the scanner type of the current scan. Example: all,sast,dast,sca...")
 
 	scanCmd.Flags().StringP("image", "I", "", "image to scan with container security products")
 	scanCmd.Flags().StringP("agent", "a", "", "agent name for agent type scanners")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -63,7 +63,7 @@ func init() {
 	scanCmd.Flags().Bool("override", false, "overrides the old analyzed results for the source branch of the PR scan")
 	scanCmd.Flags().Bool("no-decoration", false, "disables the PR decoration of the PR scan feature. Deprecated, remove the pr-number flag to disable PR decoration")
 	scanCmd.Flags().StringP("pr-number", "", "", "a pull request number to set only PR decoration on it. Supported ALMs: [GitHub, GitLab, Azure, Bitbucket]. It does not trigger the PR scan, it only sets the PR decoration")
-	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify the comma separated scanner types for pr decoration vulnerability summary. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
+	scanCmd.Flags().StringSlice("pr-decoration-scanner-types", nil, "specify comma separated scanner types for the project vulnerability summary of pr decoration. By default, it uses the scanner type of the scan. Example: all,sast,dast,sca...")
 
 	scanCmd.Flags().StringP("image", "I", "", "image to scan with container security products")
 	scanCmd.Flags().StringP("agent", "a", "", "agent name for agent type scanners")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1211,7 +1211,7 @@ func getScanMode(cmd *cobra.Command) uint {
 	byProjectORRepo := byProject || byRepo
 	byPR := byMergeTarget && byBranch
 
-	byProjectAndTool := byProjectORRepo && byTool && !byPR //
+	byProjectAndTool := byProjectORRepo && byTool && !byPR
 	byProjectAndToolAndFile := byProjectAndTool && byImportFile
 	byProjectAndToolAndForkScan := byProjectORRepo && byTool && byForkScan && !byPR
 	byProjectAndToolAndPullRequestNumber := byProjectORRepo && byTool && byPRNumber && !byImportFile


### PR DESCRIPTION
* Deprecates the no-decoration flag.
* Adds a new flag to filter vulnerability summary on pr decoration.
* Separates the PR Scan feature and PR decoration features.
    * PR Decoration: It only puts a decorated PR commend on the PR that provided by the pr-number flag.
    * PR Scan: It requires a current branch and merge-target branch to simulate a local pull request of the given branches. Some docker-based open-source scanner tools can directly scan this merged code base. If you want to include these scan results in the pull request as a decoration, you should also use the pr-number flag to specify the pr number.
* Updates the scan command help comments.