### PR TITLE
Support business criticality option when create a project

### DIFF
--- a/client/projects.go
+++ b/client/projects.go
@@ -104,6 +104,7 @@ type ProjectDetail struct {
 	// FeatureBranchInfiniteRetention holds a value that disables the feature branch retention period.
 	FeatureBranchInfiniteRetention bool   `json:"feature_branch_no_retention"`
 	DefaultBranch                  string `json:"default_branch"`
+	Criticality                    string `json:"criticality"`
 }
 
 type ProjectSource struct {

--- a/client/projects.go
+++ b/client/projects.go
@@ -104,7 +104,7 @@ type ProjectDetail struct {
 	// FeatureBranchInfiniteRetention holds a value that disables the feature branch retention period.
 	FeatureBranchInfiniteRetention bool   `json:"feature_branch_no_retention"`
 	DefaultBranch                  string `json:"default_branch"`
-	Criticality                    string `json:"criticality"`
+	CriticalityLevel               int    `json:"criticality_level"`
 }
 
 type ProjectSource struct {

--- a/cmd/createProjects.go
+++ b/cmd/createProjects.go
@@ -27,7 +27,7 @@ func init() {
 	createCmd.AddCommand(createProjectCmd)
 
 	createProjectCmd.Flags().String("project-name", "", "name of the project")
-	createProjectCmd.Flags().String("criticality", "", "business criticality of the project")
+	createProjectCmd.Flags().String("criticality", "", "business criticality of the project, possible values are [ Major, High, Medium, Low, None, Auto ]. Default is [None]")
 	createProjectCmd.Flags().Bool("force-create", false, "ignore if the URL is used by another Kondukto project")
 	createProjectCmd.Flags().StringP("overwrite", "w", "", "rename the project name when creating a new project")
 	createProjectCmd.Flags().StringP("labels", "l", "", "comma separated label names")


### PR DESCRIPTION
Users can specify project's business criticality when create it.