### PR TITLE
Hotfix #v1.42.5: Fork scan custom parameters update bug

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1053,25 +1053,6 @@ func (s *Scan) findScanIDByProjectToolAndForkScan() (string, error) {
 		return "", errors.New("fork-source flag cannot be empty when override-fork-source flag is set")
 	}
 
-	params := &client.ScanSearchParams{
-		Tool:             tool,
-		Branch:           branch,
-		MetaData:         meta,
-		Environment:      applicationEnvironment,
-		ForkScan:         forkScan,
-		ForkSourceBranch: forkSourceBranch,
-		Limit:            1,
-	}
-
-	scan, err := s.client.FindScan(project.Name, params)
-	if err != nil {
-		failedToGetCompletedScanError(project.Name, err)
-	}
-
-	if scan != nil {
-		return s.restartScanByScanID(scan.ID)
-	}
-
 	sp, err := s.client.FindScanparams(project.Name, &client.ScanparamSearchParams{
 		ToolID:           scanner.ID,
 		Branch:           branch,


### PR DESCRIPTION
Removes the direct restart flow from the _-B_ flag.