### PR TITLE
Hotfix: Add the missing SBOM stage for release status

### DIFF
--- a/client/projects.go
+++ b/client/projects.go
@@ -162,6 +162,7 @@ type ReleaseStatus struct {
 	CS             PlaybookTypeDetail `json:"cs"`
 	IAC            PlaybookTypeDetail `json:"iac"`
 	MAST           PlaybookTypeDetail `json:"mast"`
+	SBOM           PlaybookTypeDetail `json:"sbom"`
 	INFRA          PlaybookTypeDetail `json:"infra"`
 }
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -36,6 +36,7 @@ func init() {
 	releaseCmd.Flags().Bool("cs", false, "cs criteria status")
 	releaseCmd.Flags().Bool("iac", false, "iac criteria status")
 	releaseCmd.Flags().Bool("mast", false, "mast criteria status")
+	releaseCmd.Flags().Bool("sbom", false, "sbom criteria status")
 	releaseCmd.Flags().Int("timeout", 5, "minutes to wait for release criteria check to finish")
 	_ = releaseCmd.MarkFlagRequired("project")
 }
@@ -79,9 +80,9 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 	}
 
 	releaseCriteriaRows := []Row{
-		{Columns: []string{"STATUS", "SAST", "DAST", "PENTEST", "IAST", "SCA", "CS", "IAC", "MAST"}},
-		{Columns: []string{"------", "----", "----", "-------", "----", "---", "--", "---", "----"}},
-		{Columns: []string{rs.Status, rs.SAST.Status, rs.DAST.Status, rs.PENTEST.Status, rs.IAST.Status, rs.SCA.Status, rs.CS.Status, rs.IAC.Status, rs.MAST.Status}},
+		{Columns: []string{"STATUS", "SAST", "DAST", "PENTEST", "IAST", "SCA", "CS", "IAC", "MAST", "SBOM"}},
+		{Columns: []string{"------", "----", "----", "-------", "----", "---", "--", "---", "----", "----"}},
+		{Columns: []string{rs.Status, rs.SAST.Status, rs.DAST.Status, rs.PENTEST.Status, rs.IAST.Status, rs.SCA.Status, rs.CS.Status, rs.IAC.Status, rs.MAST.Status, rs.SBOM.Status}},
 	}
 	TableWriter(releaseCriteriaRows...)
 
@@ -125,7 +126,12 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		qwm(ExitCodeError, "failed to parse mast flag")
 	}
 
-	isSpecific := sast || dast || pentest || iast || sca || cs || iac || mast
+	sbom, err := cmd.Flags().GetBool("sbom")
+	if err != nil {
+		qwm(ExitCodeError, "failed to parse sbom flag")
+	}
+
+	isSpecific := sast || dast || pentest || iast || sca || cs || iac || mast || sbom
 
 	var spesificMap = make(map[string]bool, 0)
 	spesificMap["SAST"] = sast
@@ -136,6 +142,7 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 	spesificMap["CS"] = cs
 	spesificMap["IAC"] = iac
 	spesificMap["MAST"] = mast
+	spesificMap["SBOM"] = sbom
 
 	isReleaseFailed(rs, isSpecific, spesificMap)
 }
@@ -173,6 +180,9 @@ func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap
 	if release.MAST.Status == statusFail {
 		failedScans["MAST"] = release.MAST.ScanID
 	}
+	if release.SBOM.Status == statusFail {
+		failedScans["SBOM"] = ""
+	}
 
 	if verbose {
 		c, err := client.New()
@@ -190,12 +200,15 @@ func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap
 			fmt.Println()
 			fmt.Println("-----------------------------------------------------------------")
 			fmt.Printf("[!] project does not pass release criteria due to [%s] failure\n", toolType)
-			scan, err := c.FindScanByID(scanID)
-			if err != nil {
-				qwe(ExitCodeError, err, "failed to fetch scan summary")
-			}
 
-			printScanSummary(scan)
+			// SBOM doesn't have a scan_id, skip fetching scan details
+			if scanID != "" {
+				scan, err := c.FindScanByID(scanID)
+				if err != nil {
+					qwe(ExitCodeError, err, "failed to fetch scan summary")
+				}
+				printScanSummary(scan)
+			}
 			fmt.Println("-----------------------------------------------------------------")
 		}
 	}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -86,6 +86,11 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 	}
 	TableWriter(releaseCriteriaRows...)
 
+	scannerTypeSpecified, scannerTypeMap := parseReleaseFlags(cmd)
+	isReleaseFailed(rs, scannerTypeSpecified, scannerTypeMap)
+}
+
+func parseReleaseFlags(cmd *cobra.Command) (bool, map[string]bool) {
 	sast, err := cmd.Flags().GetBool("sast")
 	if err != nil {
 		qwm(ExitCodeError, "failed to parse sast flag")
@@ -131,23 +136,24 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		qwm(ExitCodeError, "failed to parse sbom flag")
 	}
 
-	isSpecific := sast || dast || pentest || iast || sca || cs || iac || mast || sbom
+	scannerTypeSpecified := sast || dast || pentest || iast || sca || cs || iac || mast || sbom
 
-	var spesificMap = make(map[string]bool, 0)
-	spesificMap["SAST"] = sast
-	spesificMap["DAST"] = dast
-	spesificMap["PENTEST"] = pentest
-	spesificMap["IAST"] = iast
-	spesificMap["SCA"] = sca
-	spesificMap["CS"] = cs
-	spesificMap["IAC"] = iac
-	spesificMap["MAST"] = mast
-	spesificMap["SBOM"] = sbom
+	scannerTypeMap := map[string]bool{
+		"SAST":    sast,
+		"DAST":    dast,
+		"PENTEST": pentest,
+		"IAST":    iast,
+		"SCA":     sca,
+		"CS":      cs,
+		"IAC":     iac,
+		"MAST":    mast,
+		"SBOM":    sbom,
+	}
 
-	isReleaseFailed(rs, isSpecific, spesificMap)
+	return scannerTypeSpecified, scannerTypeMap
 }
 
-func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap map[string]bool) {
+func isReleaseFailed(release *client.ReleaseStatus, scannerTypeSpecified bool, scannerTypeMap map[string]bool) {
 	const statusFail = "fail"
 
 	if release.Status != statusFail {
@@ -191,8 +197,8 @@ func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap
 		}
 
 		for toolType, scanID := range failedScans {
-			if isSpecific {
-				if !specificMap[toolType] {
+			if scannerTypeSpecified {
+				if !scannerTypeMap[toolType] {
 					continue
 				}
 			}
@@ -216,8 +222,8 @@ func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap
 	var failedToolTypes []string
 
 	for toolType := range failedScans {
-		if isSpecific {
-			if specificMap[toolType] {
+		if scannerTypeSpecified {
+			if scannerTypeMap[toolType] {
 				failedToolTypes = append(failedToolTypes, toolType)
 			}
 		} else {
@@ -226,7 +232,7 @@ func isReleaseFailed(release *client.ReleaseStatus, isSpecific bool, specificMap
 	}
 
 	if len(failedToolTypes) == 0 {
-		returnMSG := fmt.Sprintf("project passes release criteria")
+		returnMSG := "project passes release criteria"
 		qwe(ExitCodeSuccess, errors.New(returnMSG))
 	} else {
 		returnMSG := fmt.Sprintf("project does not pass release criteria due to [%s] failure", strings.Join(failedToolTypes, ", "))

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1497,6 +1497,10 @@ func isScanReleaseFailed(scan *client.ScanDetail, release *client.ReleaseStatus,
 		failedScans["MAST"] = scan.ID
 	}
 
+	if release.SBOM.Status == statusFail {
+		failedScans["SBOM"] = ""
+	}
+
 	if release.INFRA.Status == statusFail {
 		failedScans["INFRA"] = scan.ID
 	}
@@ -1522,12 +1526,16 @@ func isScanReleaseFailed(scan *client.ScanDetail, release *client.ReleaseStatus,
 			fmt.Println()
 			fmt.Println("-----------------------------------------------------------------")
 			fmt.Printf("[!] project does not pass release criteria due to [%s] failure\n", toolType)
-			scan, err := c.FindScanByID(scanID)
-			if err != nil {
-				return fmt.Errorf("failed to fetch scan [%s] summary: %w", scanID, err)
-			}
 
-			printScanSummary(scan)
+			// SBOM doesn't have a scan_id, skip fetching scan details
+			if scanID != "" {
+				scan, err := c.FindScanByID(scanID)
+				if err != nil {
+					return fmt.Errorf("failed to fetch scan [%s] summary: %w", scanID, err)
+				}
+
+				printScanSummary(scan)
+			}
 			fmt.Println("-----------------------------------------------------------------")
 		}
 	}


### PR DESCRIPTION
 ---
  Add SBOM Support to Release Status Command

  Changes
  1. client/projects.go
    - Added SBOM field to ReleaseStatus struct
  2. cmd/release.go
    - Added --sbom flag for filtering SBOM-specific status checks
    - Updated status table output to include SBOM column
    - Added SBOM failure detection in isReleaseFailed function
    - Fixed verbose mode to skip scan detail fetch for SBOM (SBOM has no scan_id field)

  Testing

  - ✅ Build successful
  - ✅ All existing tests pass
  - ✅ Verified --sbom flag appears in help output
  - ✅ No compilation errors

  Expected Behavior After Fix

  - kdt release will display SBOM status in the output table
  - Command will properly fail with non-zero exit code when SBOM criteria fails
  - Aligns pipeline behavior with UI status display
  - Supports --sbom flag for specific SBOM status checking
  - Works correctly in verbose mode without "scan id cannot be empty" errors

s1: the release status is failed due to SBOM rules
<img width="1085" height="178" alt="Screenshot 2025-11-26 at 17 20 12" src="https://github.com/user-attachments/assets/0b7e6eee-0355-4c8c-a83f-ba48b5c9ea77" />

s2: the SBOM related rules are passed successfully
<img width="1118" height="82" alt="Screenshot 2025-11-26 at 17 21 36" src="https://github.com/user-attachments/assets/c3fe836a-bfd2-4fb3-8b21-e495c9977b35" />

 