### PR TITLE
Add VEX commands for managing Vulnerability Exploitability eXchange imports

### DIFF
--- a/.github/workflows/invicti-aspm-nancy.yml
+++ b/.github/workflows/invicti-aspm-nancy.yml
@@ -43,7 +43,7 @@ jobs:
         id: setup_go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: 1.23
+          go-version: 1.26.3
           cache: true
           cache-dependency-path: ./go.sum
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: 1.23.x
+          go-version: 1.26.x
           cache: true
           cache-dependency-path: ./go.sum
 

--- a/client/vex.go
+++ b/client/vex.go
@@ -1,0 +1,158 @@
+/*
+Copyright © 2019 Invicti Security
+https://www.invicti.com/
+*/
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+type VexImport struct {
+	ID           string    `json:"id"`
+	ProjectID    string    `json:"project_id"`
+	Filename     string    `json:"filename"`
+	DocumentID   string    `json:"document_id,omitempty"`
+	Author       string    `json:"author,omitempty"`
+	Version      int       `json:"version,omitempty"`
+	DocumentTime time.Time `json:"document_time,omitempty"`
+	StatementCnt int       `json:"statement_count"`
+	UploadedBy   string    `json:"uploaded_by"`
+	UploadedAt   time.Time `json:"uploaded_at"`
+	Type         string    `json:"type"`
+	Tooling      string    `json:"tooling,omitempty"`
+}
+
+type VexStatement struct {
+	ID                   string    `json:"id"`
+	ImportID             string    `json:"import_id"`
+	VulnerabilityID      string    `json:"vulnerability_id"`
+	VulnerabilityAliases []string  `json:"vulnerability_aliases,omitempty"`
+	PURL                 string    `json:"purl,omitempty"`
+	State                string    `json:"state"`
+	Justification        string    `json:"justification,omitempty"`
+	ImpactStatement      string    `json:"impact_statement,omitempty"`
+	ActionStatement      string    `json:"action_statement,omitempty"`
+	StatusNotes          string    `json:"status_notes,omitempty"`
+	StatementTimestamp   time.Time `json:"statement_timestamp,omitempty"`
+	DocumentTimestamp    time.Time `json:"document_timestamp,omitempty"`
+	CreatedAt            time.Time `json:"created_at"`
+}
+
+func (c *Client) ListVexImports(projectID string) ([]VexImport, int, error) {
+	path := fmt.Sprintf("/api/v2/projects/%s/vex/imports", projectID)
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	q := req.URL.Query()
+	q.Set("start", "0")
+	q.Set("limit", "20")
+	req.URL.RawQuery = q.Encode()
+
+	var res struct {
+		Total int         `json:"total"`
+		Data  []VexImport `json:"data"`
+	}
+	if _, err = c.do(req, &res); err != nil {
+		return nil, 0, err
+	}
+
+	return res.Data, res.Total, nil
+}
+
+func (c *Client) GetVexImport(projectID, importID string, includeStatements bool) (*VexImport, []VexStatement, error) {
+	path := fmt.Sprintf("/api/v2/projects/%s/vex/imports/%s", projectID, importID)
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if includeStatements {
+		q := req.URL.Query()
+		q.Set("include_statements", "true")
+		req.URL.RawQuery = q.Encode()
+	}
+
+	var res struct {
+		Data       VexImport      `json:"data"`
+		Statements []VexStatement `json:"statements,omitempty"`
+	}
+	if _, err = c.do(req, &res); err != nil {
+		return nil, nil, err
+	}
+
+	return &res.Data, res.Statements, nil
+}
+
+func (c *Client) UploadVexImport(projectID, filePath string) (*VexImport, error) {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("file not found: %s", filePath)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("file", filepath.Base(f.Name()))
+	if err != nil {
+		return nil, err
+	}
+	if _, err = io.Copy(part, f); err != nil {
+		return nil, err
+	}
+	_ = writer.Close()
+
+	path := fmt.Sprintf("/api/v2/projects/%s/vex/imports", projectID)
+	rel := &url.URL{Path: path}
+	u := c.BaseURL.ResolveReference(rel)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("X-Cookie", viper.GetString("token"))
+
+	var res struct {
+		Data VexImport `json:"data"`
+	}
+	if _, err = c.do(req, &res); err != nil {
+		return nil, err
+	}
+
+	return &res.Data, nil
+}
+
+func (c *Client) DeleteVexImport(projectID, importID string) error {
+	path := fmt.Sprintf("/api/v2/projects/%s/vex/imports/%s", projectID, importID)
+	req, err := c.newRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+
+	var res struct {
+		Message string `json:"message"`
+	}
+	_, err = c.do(req, &res)
+	return err
+}

--- a/cmd/vex.go
+++ b/cmd/vex.go
@@ -1,0 +1,221 @@
+/*
+Copyright © 2019 Invicti Security
+https://www.invicti.com/
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/kondukto-io/kdt/client"
+	"github.com/kondukto-io/kdt/klog"
+)
+
+var vexCmd = &cobra.Command{
+	Use:   "vex",
+	Short: "manage VEX (Vulnerability Exploitability eXchange) imports",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			qwm(ExitCodeSuccess, "")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(vexCmd)
+
+	vexCmd.AddCommand(listVexCmd)
+	listVexCmd.Flags().StringP("project", "p", "", "Invicti ASPM project name")
+	_ = listVexCmd.MarkFlagRequired("project")
+
+	vexCmd.AddCommand(getVexCmd)
+	getVexCmd.Flags().StringP("project", "p", "", "Invicti ASPM project name")
+	getVexCmd.Flags().StringP("import-id", "i", "", "VEX import ID")
+	getVexCmd.Flags().Bool("include-statements", false, "include VEX statements in the response")
+	_ = getVexCmd.MarkFlagRequired("project")
+	_ = getVexCmd.MarkFlagRequired("import-id")
+
+	vexCmd.AddCommand(importVexCmd)
+	importVexCmd.Flags().StringP("project", "p", "", "Invicti ASPM project name")
+	importVexCmd.Flags().StringP("file", "f", "", "OpenVEX JSON file to upload")
+	_ = importVexCmd.MarkFlagRequired("project")
+	_ = importVexCmd.MarkFlagRequired("file")
+
+	vexCmd.AddCommand(deleteVexCmd)
+	deleteVexCmd.Flags().StringP("project", "p", "", "Invicti ASPM project name")
+	deleteVexCmd.Flags().StringP("import-id", "i", "", "VEX import ID to delete")
+	_ = deleteVexCmd.MarkFlagRequired("project")
+	_ = deleteVexCmd.MarkFlagRequired("import-id")
+}
+
+var listVexCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list VEX imports for a project",
+	Run:   listVexRootCommand,
+}
+
+func listVexRootCommand(cmd *cobra.Command, _ []string) {
+	c, err := client.New()
+	if err != nil {
+		qwe(ExitCodeError, err, "could not initialize Invicti ASPM client")
+	}
+
+	projectName := cmd.Flag("project").Value.String()
+	project, err := c.FindProjectByName(projectName)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not find project")
+	}
+
+	imports, total, err := c.ListVexImports(project.ID)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not list VEX imports")
+	}
+
+	if len(imports) == 0 {
+		qwm(ExitCodeSuccess, "no VEX imports found for project")
+	}
+
+	if total > len(imports) {
+		klog.Printf("showing %d of %d VEX imports (use pagination to see more)", len(imports), total)
+	}
+
+	rows := []Row{
+		{Columns: []string{"ID", "FILENAME", "TYPE", "AUTHOR", "STATEMENTS", "UPLOADED_BY", "UPLOADED_AT"}},
+		{Columns: []string{"--", "--------", "----", "------", "----------", "-----------", "-----------"}},
+	}
+	for _, imp := range imports {
+		rows = append(rows, Row{Columns: []string{
+			imp.ID,
+			imp.Filename,
+			imp.Type,
+			imp.Author,
+			strC(imp.StatementCnt),
+			imp.UploadedBy,
+			imp.UploadedAt.Format("2006-01-02"),
+		}})
+	}
+	TableWriter(rows...)
+}
+
+var getVexCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get a VEX import by ID",
+	Run:   getVexRootCommand,
+}
+
+func getVexRootCommand(cmd *cobra.Command, _ []string) {
+	c, err := client.New()
+	if err != nil {
+		qwe(ExitCodeError, err, "could not initialize Invicti ASPM client")
+	}
+
+	projectName := cmd.Flag("project").Value.String()
+	project, err := c.FindProjectByName(projectName)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not find project")
+	}
+
+	importID := cmd.Flag("import-id").Value.String()
+	includeStatements, err := cmd.Flags().GetBool("include-statements")
+	if err != nil {
+		qwe(ExitCodeError, err, "could not parse include-statements flag")
+	}
+
+	imp, stmts, err := c.GetVexImport(project.ID, importID, includeStatements)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not get VEX import")
+	}
+
+	if imp.ID == "" {
+		qwm(ExitCodeError, "VEX import not found")
+	}
+
+	rows := []Row{
+		{Columns: []string{"ID", "FILENAME", "TYPE", "AUTHOR", "STATEMENTS", "UPLOADED_BY", "UPLOADED_AT"}},
+		{Columns: []string{"--", "--------", "----", "------", "----------", "-----------", "-----------"}},
+		{Columns: []string{
+			imp.ID,
+			imp.Filename,
+			imp.Type,
+			imp.Author,
+			strC(imp.StatementCnt),
+			imp.UploadedBy,
+			imp.UploadedAt.Format("2006-01-02"),
+		}},
+	}
+	TableWriter(rows...)
+
+	if includeStatements && len(stmts) > 0 {
+		stmtRows := []Row{
+			{Columns: []string{"ID", "VULNERABILITY_ID", "PURL", "STATE", "JUSTIFICATION", "CREATED_AT"}},
+			{Columns: []string{"--", "----------------", "----", "-----", "-------------", "----------"}},
+		}
+		for _, s := range stmts {
+			stmtRows = append(stmtRows, Row{Columns: []string{
+				s.ID,
+				s.VulnerabilityID,
+				s.PURL,
+				s.State,
+				s.Justification,
+				s.CreatedAt.Format("2006-01-02"),
+			}})
+		}
+		TableWriter(stmtRows...)
+	}
+}
+
+var importVexCmd = &cobra.Command{
+	Use:   "import",
+	Short: "import an OpenVEX document to a project",
+	Run:   importVexRootCommand,
+}
+
+func importVexRootCommand(cmd *cobra.Command, _ []string) {
+	c, err := client.New()
+	if err != nil {
+		qwe(ExitCodeError, err, "could not initialize Invicti ASPM client")
+	}
+
+	projectName := cmd.Flag("project").Value.String()
+	project, err := c.FindProjectByName(projectName)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not find project")
+	}
+
+	file := cmd.Flag("file").Value.String()
+
+	imp, err := c.UploadVexImport(project.ID, file)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not upload VEX document")
+	}
+
+	klog.Printf("VEX document uploaded successfully: [%s] (processing async)", imp.Filename)
+}
+
+var deleteVexCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete a VEX import",
+	Run:   deleteVexRootCommand,
+}
+
+func deleteVexRootCommand(cmd *cobra.Command, _ []string) {
+	c, err := client.New()
+	if err != nil {
+		qwe(ExitCodeError, err, "could not initialize Invicti ASPM client")
+	}
+
+	projectName := cmd.Flag("project").Value.String()
+	project, err := c.FindProjectByName(projectName)
+	if err != nil {
+		qwe(ExitCodeError, err, "could not find project")
+	}
+
+	importID := cmd.Flag("import-id").Value.String()
+	if err := c.DeleteVexImport(project.ID, importID); err != nil {
+		qwe(ExitCodeError, err, "could not delete VEX import")
+	}
+
+	klog.Printf("VEX import deleted: [%s]", importID)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kondukto-io/kdt
 
-go 1.23.0
+go 1.26.3
 
 require (
 	github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
## Summary

- Add VEX (Vulnerability Exploitability eXchange) commands to `kdt` CLI
- Update Go version to 1.26.3 in workflows and go.mod

## Changes

- New `vex` subcommands for importing and managing VEX documents
- Go toolchain updated to 1.26.3

## Test plan

- [ ] `kdt vex` commands work as expected
- [ ] Go build passes with updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)