### PR TITLE
[IA-1052] Allow spaces in product and project + fixes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -94,13 +94,7 @@ func New() (*Client, error) {
 
 func (c *Client) newRequest(method string, path string, body interface{}) (*http.Request, error) {
 
-	rel := &url.URL{Path: path}
-
-	if c.IsCore {
-		rel = &url.URL{Path: "api/aspm/v1" + path}
-	}
-
-	u := c.BaseURL.ResolveReference(rel)
+	u := c.resolveURL(path)
 
 	var buf io.ReadWriter
 	if body != nil {
@@ -123,13 +117,24 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", userAgent)
 
+	c.setAuthHeader(req)
+
+	return req, nil
+}
+
+func (c *Client) resolveURL(path string) *url.URL {
+	if c.IsCore {
+		return c.BaseURL.ResolveReference(&url.URL{Path: "api/aspm/v1" + path})
+	}
+	return c.BaseURL.ResolveReference(&url.URL{Path: path})
+}
+
+func (c *Client) setAuthHeader(req *http.Request) {
 	if c.IsCore {
 		req.Header.Set("X-Auth", viper.GetString("token"))
 	} else {
 		req.Header.Set("X-Cookie", viper.GetString("token"))
 	}
-
-	return req, nil
 }
 
 func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {

--- a/client/endpoint.go
+++ b/client/endpoint.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"io"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 
@@ -32,8 +30,7 @@ func (c *Client) ImportEndpoint(filePath string, projectName string) error {
 	}
 
 	path := fmt.Sprintf("/api/v2/projects/%s/apispecs", projectDoc.ID)
-	rel := &url.URL{Path: path}
-	u := c.BaseURL.ResolveReference(rel)
+	u := c.resolveURL(path)
 
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -65,7 +62,7 @@ func (c *Client) ImportEndpoint(filePath string, projectName string) error {
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("X-Cookie", viper.GetString("token"))
+	c.setAuthHeader(req)
 
 	resp, err := c.do(req, nil)
 	if err != nil {

--- a/client/sbom.go
+++ b/client/sbom.go
@@ -7,12 +7,9 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
-
-	"github.com/spf13/viper"
 
 	"github.com/kondukto-io/kdt/klog"
 )
@@ -60,8 +57,7 @@ func (c *Client) ImportSBOM(file string, repo string, form ImportForm) error {
 	form["project"] = projects[0].Name
 
 	path := fmt.Sprintf("/api/v2/projects/%s/sbom/upload", projects[0].ID)
-	rel := &url.URL{Path: path}
-	u := c.BaseURL.ResolveReference(rel)
+	u := c.resolveURL(path)
 
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -100,7 +96,7 @@ func (c *Client) ImportSBOM(file string, repo string, form ImportForm) error {
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("X-Cookie", viper.GetString("token"))
+	c.setAuthHeader(req)
 
 	type importSBOMResponse struct {
 		Message string `json:"message"`

--- a/client/scans.go
+++ b/client/scans.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -20,7 +19,6 @@ import (
 	"github.com/kondukto-io/kdt/klog"
 
 	"github.com/google/go-querystring/query"
-	"github.com/spf13/viper"
 )
 
 type (
@@ -316,8 +314,7 @@ func (c *Client) ImportScanResult(file string, form ImportForm) (string, error) 
 	klog.Debugf("importing scan results from file: %s", file)
 
 	path := "/api/v2/scans/import"
-	rel := &url.URL{Path: path}
-	u := c.BaseURL.ResolveReference(rel)
+	u := c.resolveURL(path)
 
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -359,7 +356,7 @@ func (c *Client) ImportScanResult(file string, form ImportForm) (string, error) 
 	req.Header.Add("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("X-Cookie", viper.GetString("token"))
+	c.setAuthHeader(req)
 
 	type importScanResultResponse struct {
 		EventID string `json:"event_id"`

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -52,10 +52,11 @@ func releaseRootCommand(cmd *cobra.Command, _ []string) {
 		qwe(ExitCodeError, err, "failed to parse project flag")
 	}
 
-	branch, err := getSanitizedFlagStr(cmd, "branch")
+	branch, err := cmd.Flags().GetString("branch")
 	if err != nil {
 		qwe(ExitCodeError, err, "failed to parse branch flag")
 	}
+	branch = strings.ReplaceAll(branch, " ", "")
 
 	timeoutFlag, err := cmd.Flags().GetInt("timeout")
 	if err != nil {

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/kondukto-io/kdt/client"
+	"github.com/spf13/cobra"
 )
 
 func TestScan_prepareCustomParams(t *testing.T) {
@@ -110,30 +111,31 @@ func TestScan_prepareCustomParams(t *testing.T) {
 	}
 }
 
-// TestScan_almToolFlag guards against a regression where the scan command's
-// alm-tool flag was registered with String("alm-tool", "A", ...), making "A"
-// the default value instead of the -A shorthand. With that bug, an auto-created
-// project (--create-project) would be sent to the API with ALM tool "A" when
-// the user did not explicitly pass --alm-tool.
-func TestScan_almToolFlag(t *testing.T) {
-	flag := scanCmd.Flags().Lookup("alm-tool")
-	if flag == nil {
-		t.Fatal("alm-tool flag is not registered on the scan command")
+func TestGetSanitizedFlagStr(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "internal spaces preserved", value: "My Project", want: "My Project"},
+		{name: "leading and trailing trimmed", value: "  Padded  ", want: "Padded"},
+		{name: "no spaces unchanged", value: "NoSpaces", want: "NoSpaces"},
+		{name: "empty string unchanged", value: "", want: ""},
 	}
-
-	if flag.DefValue != "" {
-		t.Errorf("alm-tool default value = %q, want empty string", flag.DefValue)
-	}
-
-	if flag.Shorthand != "A" {
-		t.Errorf("alm-tool shorthand = %q, want %q", flag.Shorthand, "A")
-	}
-
-	got, err := scanCmd.Flags().GetString("alm-tool")
-	if err != nil {
-		t.Fatalf("failed to read alm-tool flag: %v", err)
-	}
-	if got != "" {
-		t.Errorf("alm-tool value with no flag set = %q, want empty string", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("project", "", "")
+			if err := cmd.Flags().Set("project", tt.value); err != nil {
+				t.Fatalf("failed to set flag: %v", err)
+			}
+			got, err := getSanitizedFlagStr(cmd, "project")
+			if err != nil {
+				t.Errorf("getSanitizedFlagStr() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("getSanitizedFlagStr() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -64,12 +64,12 @@ func TableWriter(rows ...Row) {
 
 func strC(v int) string { return strconv.Itoa(v) }
 
-// getSanitizedFlagStr returns a flag value with all spaces removed
+// getSanitizedFlagStr returns a flag value with leading/trailing whitespace removed.
 func getSanitizedFlagStr(cmd *cobra.Command, flagName string) (string, error) {
 	value, err := cmd.Flags().GetString(flagName)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse %s flag: %w", flagName, err)
 	}
 
-	return strings.ReplaceAll(value, " ", ""), nil
+	return strings.TrimSpace(value), nil
 }


### PR DESCRIPTION
What was changed?
- allow spaces in projects and products
- fix remaining commands to work with Core - they were failing due to X-Cookie usage instead of X-Auth

This MR depends on:
https://gitlab.com/invicti-security/invicti-aspm/twrap-go/-/merge_requests/157