### PR TITLE
IA-1208: pass custom scan params in scan-by-image command

### DIFF
--- a/client/scans.go
+++ b/client/scans.go
@@ -32,6 +32,7 @@ type (
 		MetaData    string `json:"meta_data"`
 		ScanTag     string `json:"scan_tag"`
 		Environment string `json:"environment"`
+		Custom      Custom `json:"custom,omitempty"`
 	}
 
 	ScanDetail struct {
@@ -261,6 +262,7 @@ type ScanByImageInput struct {
 	MetaData    string
 	ScanTag     string
 	Environment string
+	Custom      Custom
 }
 
 func (i *ScanByImageInput) prepareRequestQueryParameters() ImageScanParams {
@@ -272,6 +274,7 @@ func (i *ScanByImageInput) prepareRequestQueryParameters() ImageScanParams {
 		MetaData:    i.MetaData,
 		ScanTag:     i.ScanTag,
 		Environment: i.Environment,
+		Custom:      i.Custom,
 	}
 }
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -313,6 +313,20 @@ func (s *Scan) scanByImage() (string, error) {
 		return "", errors.New("image name is required")
 	}
 
+	var custom client.Custom
+	if s.cmd.Flags().Changed("params") {
+		scanner, err := s.getScanner()
+		if err != nil {
+			return "", fmt.Errorf("failed to get scanner: %w", err)
+		}
+		custom.Type = scanner.CustomType
+		parsedCustom, err := s.parseCustomParams(&custom, *scanner, nil)
+		if err != nil {
+			return "", customParamsParseError(err)
+		}
+		custom = *parsedCustom
+	}
+
 	pr := &client.ScanByImageInput{
 		Project:     project.ID,
 		Tool:        tool,
@@ -321,6 +335,7 @@ func (s *Scan) scanByImage() (string, error) {
 		MetaData:    meta,
 		ScanTag:     scanTag,
 		Environment: applicationEnvironment,
+		Custom:      custom,
 	}
 	eventID, err := s.client.ScanByImage(pr)
 	if err != nil {


### PR DESCRIPTION
## Summary

  The `kdt scan --by-image` command previously ignored the `--params` flag, meaning custom scanner parameters (e.g.,
  registry auth, private credentials for Trivy) could not be forwarded to the scan request. This MR closes that gap by
  wiring `--params` support into the image scan flow.

  ## Changes

  **`client/scans.go`**
  - Added `Custom` field to both `ImageScanParams` (API request struct) and `ScanByImageInput` (input DTO)
  - Mapped the field through `prepareRequestQueryParameters()` so it reaches the API payload

  **`cmd/scan.go`**
  - When `--params` flag is present, fetches the scanner config to determine `CustomType`, then calls the existing
  `parseCustomParams()` helper to build and validate the `Custom` struct before injecting it into the scan request
  - Reuses the same custom-param parsing path already used by the regular `scan` command — no new parsing logic introduced

  ## Notes

  - No behavior change when `--params` is not passed (`Custom` is omitted via `omitempty`)
  - Unblocks private registry authentication for Trivy container scans triggered via `kdt scan --by-image`